### PR TITLE
Remove parseArgv from export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,12 +41,6 @@
       "integrity": "sha1-0KV9Jeua6rlkO90aAwZCuRwSPig=",
       "dev": true
     },
-    "@types/jest": {
-      "version": "19.2.4",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-19.2.4.tgz",
-      "integrity": "sha512-w9nmNHHkl9lNeOorjz1a7BLUd6zTa3pakNx2qkKCVtYS44L7taPcJB8l1kQWVOIa7kN08qwlyS11A1nz2yUvWQ==",
-      "dev": true
-    },
     "@types/lodash": {
       "version": "4.14.66",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.66.tgz",
@@ -4176,9 +4170,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -84,9 +84,8 @@
     "wordwrap": "^1.0.0"
   },
   "devDependencies": {
-    "@types/jest": "^19.2.4",
     "@types/lodash.merge": "^4.6.2",
-    "@types/node": "^8.0.1",
+    "@types/node": "^8.0.7",
     "@types/wordwrap": "github:types/wordwrap",
     "ava": "^0.20.0",
     "dependency-check": "^2.8.0",
@@ -94,6 +93,6 @@
     "rimraf": "^2.6.1",
     "tslint": "^5.4.3",
     "tslint-config-unional": "^0.8.0",
-    "typescript": "^2.3.4"
+    "typescript": "^2.4.1"
   }
 }

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -58,6 +58,7 @@ export class Cli {
     }
     else {
       const command = getCommand(args._.shift(), this.commands)
+
       if (!command) {
         this.ui.showHelp(this)
       }
@@ -65,12 +66,23 @@ export class Cli {
         command.ui.showHelp(command)
       }
       else {
+        const cmdArgv = rawArgv.slice(2).filter(x => ['--verbose', '-V', '--silent'].indexOf(x) === -1)
+
+        let cmdArgs
+        try {
+          cmdArgs = parseArgv(command, cmdArgv)
+        }
+        catch (e) {
+          command.ui.error(e.message)
+          command.ui.showHelp(command)
+          return
+        }
+
         const displayLevel = args.verbose ?
           DisplayLevel.Verbose : args.silent ?
             DisplayLevel.Silent : DisplayLevel.Normal
         command.ui.setDisplayLevel(displayLevel)
-        const cmdArgs = rawArgv.slice(1).filter(x => ['--verbose', '-V', '--silent'].indexOf(x) === -1)
-        return command.run(cmdArgs)
+        return command.run(cmdArgs, cmdArgv)
       }
     }
   }

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -13,7 +13,7 @@ export interface CommandSpec {
     string?: StringOptions
   }
   alias?: string[]
-  run?: (this: Command, argv: string[]) => void
+  run?: (this: Command, args: { _: string[], [name: string]: any }, argv: string[]) => void
 }
 
 export namespace Command {
@@ -32,12 +32,14 @@ export interface Command extends CommandBase, CommandSpec {
   cwd: string
   options: Command.Options
   ui: LogPresenter & HelpPresenter
-  run(this: Command, argv: string[]): Promise<void>
+  run(this: Command, args: { _: string[], [name: string]: any }, argv: string[]): Promise<void>
 }
 
 export interface Argument {
   name: string,
+  description?: string
   required?: boolean
+  multiple?: boolean
 }
 
 export interface BooleanOptions {

--- a/src/PlainPresenter.ts
+++ b/src/PlainPresenter.ts
@@ -105,8 +105,26 @@ function getCommandsNamesAndAlias(commands: CommandModel[] | undefined) {
   return result
 }
 
-function generateArgumentsSection(_command: CommandModel) {
-  return ''
+function generateArgumentsSection(command: CommandModel) {
+  if (!command.arguments) {
+    return ''
+  }
+
+  let message = 'Arguments:\n'
+  let entries: string[][] = []
+  let maxWidth = 0
+  command.arguments.forEach(a => {
+    const argStr = a.required ? `<${a.name}>` : `[${a.name}]`
+    maxWidth = Math.max(maxWidth, argStr.length)
+    entries.push([argStr, a.description || ''])
+  })
+
+  const alignedWidth = Math.max(MIN_LHS_WIDTH - INDENT, maxWidth + RIGHT_PADDING)
+
+  if (entries.length > 0) {
+    message += entries.map(e => `  ${padRight(e[0], alignedWidth, ' ')}${e[1]}`).join('\n')
+  }
+  return message
 }
 
 function generateOptionsSection(command: CommandModel) {

--- a/src/Presenter.ts
+++ b/src/Presenter.ts
@@ -1,9 +1,10 @@
-import { Command, CommandBase } from './Command'
+import { Command, CommandBase, Argument } from './Command'
 import { DisplayLevel } from './Display'
 
 export interface CommandModel extends CommandBase {
   description?: string
   commands?: CommandModel[]
+  arguments?: Argument[],
   alias?: string[]
   options?: Command.Options
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 export * from './Cli'
 export * from './Command'
 export * from './Display'
-export * from './parseArgv'
 export * from './PlainPresenter'
 export * from './Presenter'
 export * from './PresenterFactory'

--- a/src/parseArgv.spec.ts
+++ b/src/parseArgv.spec.ts
@@ -117,3 +117,94 @@ test('fill default for string option', t => {
   const actual = parseArgv(cmd, argv)
   t.deepEqual(actual, { _: [], x: 'abc' })
 })
+
+test('zero or more args should accept 0 args', t => {
+  const cmd = createCommand({
+    name: 'args',
+    arguments: [
+      {
+        name: 'zero-or-more',
+        multiple: true
+      }
+    ]
+  }, { cwd: '' })
+  const argv = []
+  const actual = parseArgv(cmd, argv)
+  t.deepEqual(actual, { _: [] })
+})
+
+
+test('zero or more args should accept 1 args', t => {
+  const cmd = createCommand({
+    name: 'args',
+    arguments: [
+      {
+        name: 'zero-or-more',
+        multiple: true
+      }
+    ]
+  }, { cwd: '' })
+  const argv = ['a', 'b']
+  const actual = parseArgv(cmd, argv)
+  t.deepEqual(actual, { _: ['b'] })
+})
+
+test('zero or more args should accept 2 args', t => {
+  const cmd = createCommand({
+    name: 'args',
+    arguments: [
+      {
+        name: 'zero-or-more',
+        multiple: true
+      }
+    ]
+  }, { cwd: '' })
+  const argv = ['a', 'b', 'c']
+  const actual = parseArgv(cmd, argv)
+  t.deepEqual(actual, { _: ['b', 'c'] })
+})
+
+test('one or more args should not accept 0 args', t => {
+  const cmd = createCommand({
+    name: 'args',
+    arguments: [
+      {
+        name: 'one-or-more',
+        multiple: true,
+        required: true
+      }
+    ]
+  }, { cwd: '' })
+  const argv = ['cli']
+  t.throws(() => parseArgv(cmd, argv))
+})
+test('one or more args should not accept 1 args', t => {
+  const cmd = createCommand({
+    name: 'args',
+    arguments: [
+      {
+        name: 'one-or-more',
+        multiple: true,
+        required: true
+      }
+    ]
+  }, { cwd: '' })
+  const argv = ['cli', 'a']
+  const actual = parseArgv(cmd, argv)
+  t.deepEqual(actual, { _: ['a'] })
+})
+test('one or more args should not accept 2 args', t => {
+  const cmd = createCommand({
+    name: 'args',
+    arguments: [
+      {
+        name: 'one-or-more',
+        multiple: true,
+        required: true
+      }
+    ]
+  }, { cwd: '' })
+  const argv = ['cli', 'a', 'b']
+  const actual = parseArgv(cmd, argv)
+  t.deepEqual(actual, { _: ['a', 'b'] })
+})

--- a/src/test/CompositeDisplay.ts
+++ b/src/test/CompositeDisplay.ts
@@ -1,0 +1,20 @@
+import { Display } from '../Display'
+
+export class CompositeDisplay implements Display {
+  displays: Display[]
+  constructor(...displays: Display[]) {
+    this.displays = displays
+  }
+  debug(...args: any[]): void {
+    this.displays.forEach(d => d.debug(...args))
+  }
+  info(...args: any[]): void {
+    this.displays.forEach(d => d.info(...args))
+  }
+  warn(...args: any[]): void {
+    this.displays.forEach(d => d.warn(...args))
+  }
+  error(...args: any[]): void {
+    this.displays.forEach(d => d.error(...args))
+  }
+}

--- a/src/test/commands.ts
+++ b/src/test/commands.ts
@@ -1,4 +1,4 @@
-import { CommandSpec, parseArgv } from '../index'
+import { CommandSpec } from '../index'
 
 export const noopCommandSpec: CommandSpec = {
   name: 'noop',
@@ -9,8 +9,13 @@ export const noopCommandSpec: CommandSpec = {
 
 export const echoCommandSpec: CommandSpec = {
   name: 'echo',
+  arguments: [{
+    name: 'args',
+    description: 'any argument(s)',
+    multiple: true
+  }],
   description: 'Echoing input arguments',
-  run(argv) {
+  run(_args, argv) {
     this.ui.info(...argv)
   }
 }
@@ -49,8 +54,7 @@ export const echoNameOptionCommandSpec = {
       }
     }
   },
-  run(argv) {
-    const args = parseArgv(this, argv)
+  run(args) {
     this.ui.info(args.name)
   }
 } as CommandSpec
@@ -63,4 +67,19 @@ export const asyncCommandSpec = {
       setImmediate(r)
     })
   }
+} as CommandSpec
+
+export const argCommandSpec = {
+  name: 'arg',
+  arguments: [
+    {
+      name: 'some-arg',
+      description: 'Some Required Arguments',
+      required: true
+    },
+    {
+      name: 'opt-arg',
+      description: 'Some Optional Arguments'
+    }
+  ]
 } as CommandSpec

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -1,5 +1,7 @@
 import { Cli } from '../Cli'
-import { InMemoryPresenter } from './InMemoryDisplay'
+
+import { CompositeDisplay } from './CompositeDisplay'
+import { InMemoryPresenter, InMemoryDisplay } from './InMemoryDisplay'
 
 export function createArgv(...args) {
   args.unshift('node', 'cli')
@@ -12,4 +14,17 @@ export function createFakeCli(...commandSpecs) {
     createCommandPresenter(options) { return new InMemoryPresenter(options) }
   }
   return new Cli('cmd', '0.0.0', commandSpecs, { presenterFactory })
+}
+
+export function spyDisplay(cli, cmdName?: string) {
+  const memDisplay = new InMemoryDisplay()
+  if (cmdName) {
+    const cmd = cli.commands.find(c => c.name === cmdName)
+    cmd.ui.display = new CompositeDisplay(cmd.ui.display, memDisplay)
+  }
+  else {
+    cli.ui.display = new CompositeDisplay(cli.ui.display, memDisplay)
+  }
+
+  return memDisplay
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -17,8 +17,12 @@ export function createCommand(spec: CommandSpec, { cwd }): Command {
 
 export function getCommand(nameOrAlias, commands: Command[]) {
   return commands.find(cmd => {
-    return cmd.name === nameOrAlias ||
+    const match = cmd.name === nameOrAlias ||
       (!!cmd.alias && cmd.alias.indexOf(nameOrAlias) !== -1)
+    if (!match && cmd.commands) {
+      return getCommand(nameOrAlias, cmd.commands)
+    }
+    return match
   })
 }
 


### PR DESCRIPTION
Run will now have the parsed args.
And only the directly matched command.run will be called.
This eliminates the need of rawArgv.
But I put it in for backward compatiability if the consumer needs it.