### PR TITLE
fix: ignore ENOENT when finding plugins.

### DIFF
--- a/src/findPlugins.ts
+++ b/src/findPlugins.ts
@@ -4,11 +4,23 @@ import path = require('path')
 export function findPlugins(keyword, cwd) {
   const folders = findPackageFolders(cwd)
   return folders.filter(f => {
-    const pjson = JSON.parse(fs.readFileSync(path.resolve(cwd, 'node_modules', f, 'package.json'), 'utf8'))
+    const pjson = JSON.parse(readFileSafe(path.resolve(cwd, 'node_modules', f, 'package.json')))
     if (!pjson || !pjson.keywords)
       return false
     return pjson.keywords.indexOf(keyword) !== -1
   })
+}
+
+function findPackageFolders(cwd): string[] {
+  let dirs = readDirSafe(path.resolve(cwd, 'node_modules'))
+  // I can safely skip `@types` as it is not possible to have plugins
+  const scopedDirs = dirs.filter(d => d.startsWith('@') && d !== '@types')
+  dirs = dirs.filter(d => !d.startsWith('@') && !d.startsWith('.'))
+  scopedDirs.forEach(sd => {
+    dirs = dirs.concat(readDirSafe(path.resolve(cwd, 'node_modules', sd)).map(d => path.join(sd, d)))
+  })
+
+  return dirs
 }
 
 function readDirSafe(path: string) {
@@ -25,14 +37,19 @@ function readDirSafe(path: string) {
   return dirs
 }
 
-function findPackageFolders(cwd): string[] {
-  let dirs = readDirSafe(path.resolve(cwd, 'node_modules'))
-  // I can safely skip `@types` as it is not possible to have plugins
-  const scopedDirs = dirs.filter(d => d.startsWith('@') && d !== '@types')
-  dirs = dirs.filter(d => !d.startsWith('@') && !d.startsWith('.'))
-  scopedDirs.forEach(sd => {
-    dirs = dirs.concat(readDirSafe(path.resolve(cwd, 'node_modules', sd)).map(d => path.join(sd, d)))
-  })
-
-  return dirs
+/**
+ * Read file and ignore ENOENT.
+ * When the the folder is a link, the link may be invalid.
+ * That will result in ENOENT.
+ * @param path file path.
+ */
+function readFileSafe(path) {
+  try {
+    return fs.readFileSync(path, 'utf8')
+  }
+  catch (err) {
+    if (err.code === 'ENOENT')
+      return ''
+    throw err
+  }
 }


### PR DESCRIPTION
That avoid error when there are `npm link` but is invalid.

Fixed: #74 