### PR TITLE
Add number option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -86,11 +86,6 @@
       "integrity": "sha512-sRCTcVQkIiQqRoQcazgN2PvRLS7d9BnSl8elRZR5UYlpm6XgU8F4j/0csz8WoaKKTUqa6rSuOy3Vph7AHfX7KQ==",
       "dev": true
     },
-    "@types/minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
-    },
     "@types/node": {
       "version": "8.0.33",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.33.tgz",
@@ -3452,7 +3447,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -6358,6 +6354,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
+      "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+      "requires": {
+        "camelcase": "4.1.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        }
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6144,9 +6144,9 @@
       }
     },
     "typescript": {
-      "version": "2.6.0-dev.20171012",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.0-dev.20171012.tgz",
-      "integrity": "sha512-KLp7Z0f++UiDRlLomR48pzOwj2We/8WPkKPn9uA5Nmm7qD9xLD0pf7qEqs7EaNHCmGSdDl5bSwU2GHuVRsb2qg==",
+      "version": "2.6.0-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.0-rc.tgz",
+      "integrity": "sha512-5dDv8NNGYmipBdXnt9mqWqIbzQ/mY5XWjrLeNEROmkHGJ6TnacHUihXi2SvKMHQsCafbJZqaSO+agMRl8F36GA==",
       "dev": true
     },
     "uid2": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,6 @@
     "rimraf": "^2.6.2",
     "tslint": "^5.7.0",
     "tslint-config-unional": "^0.8.0",
-    "typescript": "^2.6.0-dev.20171012"
+    "typescript": "^2.6.0-rc"
   }
 }

--- a/package.json
+++ b/package.json
@@ -77,13 +77,12 @@
     ]
   },
   "dependencies": {
-    "@types/minimist": "^1.2.0",
     "eventemitter2": "^4.1.2",
     "find-up": "^2.1.0",
     "lodash": "^4.17.4",
-    "minimist": "^1.2.0",
     "pad-right": "^0.2.2",
-    "wordwrap": "^1.0.0"
+    "wordwrap": "^1.0.0",
+    "yargs-parser": "^8.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.77",

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -31,13 +31,21 @@ export namespace Command {
     [optionName: string]: {
       description: string
       alias?: string[]
-      default?: string,
+      default?: string
       /**
        * An option group this option belongs to.
        * If the option belongs to a group and one of the options has be set,
        * the other options will not have their default value.
        */
       group?: string
+    }
+  }
+
+  export interface NumberOption {
+    [optionName: string]: {
+      description: string
+      alias?: string[]
+      default?: string
     }
   }
 

--- a/src/parseArgv.ts
+++ b/src/parseArgv.ts
@@ -1,4 +1,4 @@
-import minimist = require('minimist')
+import yargs = require('yargs-parser')
 
 import { Command } from './Command'
 
@@ -27,7 +27,7 @@ export interface Parsable {
 export function parseArgv(parsable: Parsable, rawArgv: string[]) {
   const options = toMinimistOption(parsable.options)
 
-  const args = minimist(rawArgv, options)
+  const args = yargs(rawArgv, options)
   args._.shift()
   if (parsable.commands) {
     return args
@@ -134,11 +134,11 @@ function extractTypes(sourceMap, valueType) {
   return map
 }
 
-function handleGroupedOptions(parsable: Parsable, args: minimist.ParsedArgs, rawArgv: string[]) {
+function handleGroupedOptions(parsable: Parsable, args: yargs.ParsedArgs, rawArgv: string[]) {
   if (!parsable.options)
     return
 
-  const noDefaults = minimist(rawArgv)
+  const noDefaults = yargs(rawArgv)
   const groups = getAllGroups(parsable.options)
   function getAllGroups(opts) {
     const groups = {}

--- a/src/parseArgv.ts
+++ b/src/parseArgv.ts
@@ -20,12 +20,13 @@ export interface Parsable {
   commands?: Parsable[]
   options?: {
     boolean?: Command.BooleanOptions
-    string?: Command.StringOptions
+    string?: Command.StringOptions,
+    number?: Command.NumberOption
   }
 }
 
 export function parseArgv(parsable: Parsable, rawArgv: string[]) {
-  const options = toMinimistOption(parsable.options)
+  const options = toYargsOption(parsable.options)
 
   const args = yargs(rawArgv, options)
   args._.shift()
@@ -40,13 +41,14 @@ export function parseArgv(parsable: Parsable, rawArgv: string[]) {
   return args
 }
 
-function toMinimistOption(options) {
+function toYargsOption(options) {
   if (!options) {
     return {}
   }
   const result: any = { alias: {}, default: {} }
   fillOptions('boolean')
   fillOptions('string')
+  fillOptions('number')
 
   return result
 
@@ -101,6 +103,7 @@ function validateOptions(command, args) {
   if (command.options) {
     map = { ...map, ...extractTypes(command.options.boolean, 'boolean') }
     map = { ...map, ...extractTypes(command.options.string, 'string') }
+    map = { ...map, ...extractTypes(command.options.number, 'number') }
   }
 
   Object.keys(args).forEach(name => {
@@ -110,6 +113,9 @@ function validateOptions(command, args) {
       }
       if (map[name] === 'string' && typeof args[name] !== 'string') {
         throw new InvalidOptionError(name, 'string', args[name])
+      }
+      if (map[name] === 'number' && typeof args[name] !== 'number') {
+        throw new InvalidOptionError(name, 'number', args[name])
       }
     }
     else {

--- a/src/test-util/createCommandArgs.spec.ts
+++ b/src/test-util/createCommandArgs.spec.ts
@@ -6,6 +6,7 @@ import { noopCommand } from './noopCommand'
 import { argCommand } from './argCommand'
 import { booleanOptionsCommand } from './booleanOptionsCommand'
 import { stringOptionCommand } from './stringOptionCommand'
+import { numberOptionCommand } from './numberOptionCommand';
 
 test('empty argv', t => {
   const args = createCommandArgs(noopCommand)
@@ -41,4 +42,10 @@ test('string option without space', t => {
   const args = createCommandArgs(stringOptionCommand, ['-a5'])
 
   t.deepEqual(args, { a: '5', _: [] })
+})
+
+test('number option', t => {
+  const args = createCommandArgs(numberOptionCommand, ['-a 3'])
+
+  t.deepEqual(args, { a: 3, _: [] })
 })

--- a/src/test-util/numberOptionCommand.ts
+++ b/src/test-util/numberOptionCommand.ts
@@ -1,0 +1,15 @@
+import { Command } from '../Command'
+
+export const numberOptionCommand = {
+  name: 'num-opt',
+  options: {
+    number: {
+      'a': {
+        description: 'number option a'
+      }
+    }
+  },
+  run(args) {
+    this.ui.info(`a: ${args.a}`)
+  }
+} as Command


### PR DESCRIPTION
Replace `minimist` with `yargs-parser` as it supports `number` natively.

Update TSC@2.6.0-rc

Fixes #81 