### PR TITLE
Rename Command to CliCommand.

### DIFF
--- a/src/Cli.spec.ts
+++ b/src/Cli.spec.ts
@@ -2,7 +2,7 @@ import test from 'ava'
 
 import { Cli } from './Cli'
 import { createCliArgv, InMemoryPresenter } from './test-util/index';
-import { Command } from './Command';
+import { CliCommand } from './CliCommand';
 import { PresenterFactory } from './index';
 import { echoAllCommand } from './test-util/echoAllCommand';
 import { logLevel, getLevel } from '@unional/logging';
@@ -81,7 +81,7 @@ test('support extending context', t => {
       run() {
         t.not(this.custom, undefined)
       }
-    } as Command<undefined, { custom: boolean }>]
+    } as CliCommand<undefined, { custom: boolean }>]
   }, { cwd: '', custom: true })
   return cli.parse(createCliArgv('cli', 'cmd'))
 })
@@ -132,7 +132,7 @@ test('read local json file', async t => {
       run() {
         t.deepEqual(this.config, { a: 1 })
       }
-    } as Command<{ a: number }, {}>]
+    } as CliCommand<{ a: number }, {}>]
   }, { cwd: 'fixtures/has-config' })
   t.plan(1)
   await cli.parse(createCliArgv('cli', 'cfg'))
@@ -147,7 +147,7 @@ test(`read local json file in parent directory`, async t => {
       run() {
         t.deepEqual(this.config, { a: 1 })
       }
-    } as Command<{ a: number }, {}>]
+    } as CliCommand<{ a: number }, {}>]
   }, { cwd: 'fixtures/has-config/sub-folder' })
   t.plan(1)
   await cli.parse(createCliArgv('cli', 'cfg'))

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -2,7 +2,7 @@ import { addAppender, logLevel } from '@unional/logging'
 import { ColorAppender } from 'aurelia-logging-color'
 import yargs = require('yargs-parser')
 
-import { Command } from './Command'
+import { CliCommand, CliCommandInstance } from './CliCommand'
 import { DisplayLevel } from './Display'
 import { parseArgv } from './parseArgv'
 import { LogPresenter, HelpPresenter, VersionPresenter } from './Presenter'
@@ -14,7 +14,7 @@ import { loadConfig } from './loadConfig'
 export interface CliOption {
   name: string
   version: string
-  commands: Command[]
+  commands: CliCommand[]
 }
 
 export interface CliContext {
@@ -54,7 +54,7 @@ export class Cli<Context extends { [i: string]: any } = {}> {
       }
     }
   }
-  commands: Command.Instance[]
+  commands: CliCommandInstance[]
   name: string
   version: string
   private ui: LogPresenter & HelpPresenter & VersionPresenter

--- a/src/CliCommand.spec.ts
+++ b/src/CliCommand.spec.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 
-import { Command } from './Command'
+import { CliCommand } from './CliCommand'
 
 test('using custom context', t => {
   const spec = {
@@ -8,7 +8,7 @@ test('using custom context', t => {
     run() {
       t.falsy(this.x)
     }
-  } as Command<undefined, { x: string }>
+  } as CliCommand<undefined, { x: string }>
 
   t.truthy(spec)
 
@@ -18,7 +18,7 @@ test('using custom context', t => {
       // `this` should be `Command` by default
       t.truthy(this.ui)
     }
-  } as Command
+  } as CliCommand
 
   t.truthy(spec2)
 })

--- a/src/CliCommand.ts
+++ b/src/CliCommand.ts
@@ -1,5 +1,5 @@
 import { LogPresenter, HelpPresenter, Inquirer } from './Presenter'
-export namespace Command {
+export namespace CliCommand {
 
   export interface Base {
     name: string
@@ -67,18 +67,19 @@ export namespace Command {
     description?: string
     options?: Options
     alias?: string[]
-    run?: (this: Instance & Context & { config?: Config }, args: { _: string[], _defaults: string[], [name: string]: any }, argv: string[]) => void | Promise<any>
+    run?: (this: CliCommandInstance & Context & { config?: Config }, args: { _: string[], _defaults: string[], [name: string]: any }, argv: string[]) => void | Promise<any>
   }
 
-  export interface Instance<Config = {}, Context = {}> extends Base, Shared<Config, Context> {
-    cwd: string
-    commands?: Instance[]
-    config?: Config
-    ui: LogPresenter & HelpPresenter & Inquirer
-    run: (this: Instance & Context & { config?: Config }, args: { _: string[], _defaults: string[], [name: string]: any }, argv: string[]) => void | Promise<any>
-  }
 }
 
-export interface Command<Config = {}, Context = {}> extends Command.Shared<Config, Context> {
-  commands?: Command[]
+export interface CliCommandInstance<Config = {}, Context = {}> extends CliCommand.Base, CliCommand.Shared<Config, Context> {
+  cwd: string
+  commands?: CliCommandInstance[]
+  config?: Config
+  ui: LogPresenter & HelpPresenter & Inquirer
+  run: (this: CliCommandInstance & Context & { config?: Config }, args: { _: string[], _defaults: string[], [name: string]: any }, argv: string[]) => void | Promise<any>
+}
+
+export interface CliCommand<Config = {}, Context = {}> extends CliCommand.Shared<Config, Context> {
+  commands?: CliCommand[]
 }

--- a/src/Presenter.ts
+++ b/src/Presenter.ts
@@ -1,13 +1,13 @@
 import inquirer = require('inquirer')
-import { Command } from './Command'
+import { CliCommand } from './CliCommand'
 import { DisplayLevel } from './Display'
 
-export interface CommandModel extends Command.Base {
+export interface CommandModel extends CliCommand.Base {
   description?: string
   commands?: CommandModel[]
-  arguments?: Command.Argument[],
+  arguments?: CliCommand.Argument[],
   alias?: string[]
-  options?: Command.Options
+  options?: CliCommand.Options
 }
 
 export interface LogPresenter {

--- a/src/createParsable.ts
+++ b/src/createParsable.ts
@@ -1,7 +1,11 @@
-import { Command } from './Command'
+import {
+  CliCommand,
+  // @ts-ignore
+  CliCommandInstance
+} from './CliCommand'
 import { InMemoryPresenterFactory } from './test-util/index'
 import { createCommand } from './util'
 
-export function createParsable(command: Command, context = {}) {
+export function createParsable(command: CliCommand, context = {}) {
   return createCommand(command, new InMemoryPresenterFactory(), context)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from './Cli'
-export * from './Command'
+export * from './CliCommand'
 export * from './Display'
 export * from './PlainPresenter'
 export * from './PluginCli'

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,12 +1,12 @@
-import { Command } from './Command'
+import { CliCommand } from './CliCommand'
 
 export interface Parsable {
   name: string
-  arguments?: Command.Argument[]
+  arguments?: CliCommand.Argument[]
   commands?: Parsable[]
   options?: {
-    boolean?: Command.BooleanOptions
-    string?: Command.StringOptions,
-    number?: Command.NumberOptions
+    boolean?: CliCommand.BooleanOptions
+    string?: CliCommand.StringOptions,
+    number?: CliCommand.NumberOptions
   }
 }

--- a/src/loadPlugins.ts
+++ b/src/loadPlugins.ts
@@ -2,17 +2,17 @@ import path = require('path')
 import findup = require('find-up')
 
 import { findPlugins } from './findPlugins'
-import { Command } from './Command'
+import { CliCommand } from './CliCommand'
 import { log } from './log';
 
 export interface Registrar {
-  addCommand(command: Command<any, { [x: string]: any }>): void
+  addCommand(command: CliCommand<any, { [x: string]: any }>): void
 }
 
 class CliRegistrarImpl {
-  command: Command
+  command: CliCommand
 
-  addCommand(command: Command) {
+  addCommand(command: CliCommand) {
     this.command = command
   }
 }

--- a/src/test-util/argCommand.ts
+++ b/src/test-util/argCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 export const argCommand = {
   name: 'arg',
@@ -16,4 +16,4 @@ export const argCommand = {
   run(args) {
     this.ui.info(`some-arg: ${args['some-arg']}`, `opt-arg: ${args['opt-arg']}`)
   }
-} as Command
+} as CliCommand

--- a/src/test-util/asyncCommand.ts
+++ b/src/test-util/asyncCommand.ts
@@ -1,8 +1,8 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 export const asyncCommand = {
   name: 'async',
   run() {
     return Promise.resolve()
   }
-} as Command
+} as CliCommand

--- a/src/test-util/booleanOptionsCommand.ts
+++ b/src/test-util/booleanOptionsCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 export const booleanOptionsCommand = {
   name: 'opt',
@@ -16,4 +16,4 @@ export const booleanOptionsCommand = {
   run(args) {
     this.ui.info(`a: ${args.a}, b: ${args.b}`)
   }
-} as Command
+} as CliCommand

--- a/src/test-util/echoAllCommand.ts
+++ b/src/test-util/echoAllCommand.ts
@@ -1,6 +1,6 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
-export const echoAllCommand: Command = {
+export const echoAllCommand: CliCommand = {
   name: 'echo-all',
   arguments: [{
     name: 'args',

--- a/src/test-util/echoCommand.ts
+++ b/src/test-util/echoCommand.ts
@@ -1,6 +1,6 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
-export const echoCommand: Command = {
+export const echoCommand: CliCommand = {
   name: 'echo',
   arguments: [{
     name: 'args',

--- a/src/test-util/echoNameOptionCommand.ts
+++ b/src/test-util/echoNameOptionCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 export const echoNameOptionCommand = {
   name: 'echoNameOption',
@@ -15,4 +15,4 @@ export const echoNameOptionCommand = {
   run(args) {
     this.ui.info(args.name)
   }
-} as Command
+} as CliCommand

--- a/src/test-util/errorCommand.ts
+++ b/src/test-util/errorCommand.ts
@@ -1,6 +1,6 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
-export const errorCommand: Command = {
+export const errorCommand: CliCommand = {
   name: 'error',
   run() {
     this.ui.error('error...')

--- a/src/test-util/getDisplay.ts
+++ b/src/test-util/getDisplay.ts
@@ -1,8 +1,8 @@
-import { Command } from '../Command'
+import { CliCommandInstance } from '../CliCommand'
 import { Cli } from '../Cli'
 
 import { InMemoryDisplay } from './InMemoryDisplay'
 
-export function getDisplay(subject: Cli | Command.Instance): InMemoryDisplay {
+export function getDisplay(subject: Cli | CliCommandInstance): InMemoryDisplay {
   return (subject as any).ui.display
 }

--- a/src/test-util/groupOptionsCommand.ts
+++ b/src/test-util/groupOptionsCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 export const groupOptionsCommand = {
   name: 'opt',
@@ -18,4 +18,4 @@ export const groupOptionsCommand = {
   run(args) {
     this.ui.info(`a: ${args.a}, b: ${args.b}`)
   }
-} as Command
+} as CliCommand

--- a/src/test-util/noopCommand.ts
+++ b/src/test-util/noopCommand.ts
@@ -1,7 +1,7 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 // istanbul ignore next
-export const noopCommand: Command = {
+export const noopCommand: CliCommand = {
   name: 'noop',
   run() {
     return

--- a/src/test-util/numberOptionCommand.ts
+++ b/src/test-util/numberOptionCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 export const numberOptionCommand = {
   name: 'num-opt',
@@ -12,4 +12,4 @@ export const numberOptionCommand = {
   run(args) {
     this.ui.info(`a: ${args.a}`)
   }
-} as Command
+} as CliCommand

--- a/src/test-util/setup.ts
+++ b/src/test-util/setup.ts
@@ -1,5 +1,9 @@
 import { Cli } from '../Cli';
-import { Command } from '../Command';
+import {
+  CliCommand,
+  // @ts-ignore
+  CliCommandInstance
+} from '../CliCommand';
 import { TaskConstructor, Task, ViewBuilder, createTaskRunner } from '../Task'
 import { createCommand } from '../util'
 
@@ -34,7 +38,7 @@ export function createInMemoryCli(name: string, ...commands): Cli<any> {
     })
 }
 
-export function setupCommandTest(command: Command, argv: string[], context = {}) {
+export function setupCommandTest(command: CliCommand, argv: string[], context = {}) {
   const presenterFactory = new InMemoryPresenterFactory()
   const args = createCommandArgs(command, argv)
   const cmd = createCommand(command, presenterFactory, context)

--- a/src/test-util/stringOptionCommand.ts
+++ b/src/test-util/stringOptionCommand.ts
@@ -1,4 +1,4 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
 export const stringOptionCommand = {
   name: 'opt',
@@ -12,4 +12,4 @@ export const stringOptionCommand = {
   run(args) {
     this.ui.info(`a: ${args.a}`)
   }
-} as Command
+} as CliCommand

--- a/src/test-util/verboseCommand.ts
+++ b/src/test-util/verboseCommand.ts
@@ -1,6 +1,6 @@
-import { Command } from '../Command'
+import { CliCommand } from '../CliCommand'
 
-export const verboseCommand: Command = {
+export const verboseCommand: CliCommand = {
   name: 'verbose',
   alias: ['vb', 'detail'],
   options: {

--- a/src/test/DummyPlugin.ts
+++ b/src/test/DummyPlugin.ts
@@ -1,6 +1,6 @@
 import { Emitter, createEvent } from 'fsa-emitter'
 
-import { Registrar, Command, createTaskRunner, Task, ViewContext } from '../index'
+import { Registrar, CliCommand, createTaskRunner, Task, ViewContext } from '../index'
 
 const message = createEvent<string>('dummy')
 
@@ -22,7 +22,7 @@ const DummyCommand = {
     const runner = createTaskRunner(this, DummyTask, dummyViewBuilder)
     runner.run()
   }
-} as Command
+} as CliCommand
 
 export function activate(cli: Registrar) {
   cli.addCommand(DummyCommand)

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,15 +1,15 @@
-import { Command } from './Command'
+import { CliCommand, CliCommandInstance } from './CliCommand'
 import { PresenterFactory } from './PresenterFactory';
 import { log } from './log';
 
-export function createCommand(spec: Command, presenterFactory: PresenterFactory, context: { [index: string]: any }): Command.Instance {
+export function createCommand(spec: CliCommand, presenterFactory: PresenterFactory, context: { [index: string]: any }): CliCommandInstance {
   if (spec)
     log.debug('creatingCommand', spec.name)
   const result = {
     run: () => { return undefined },
     ...context,
     ...spec
-  } as Command.Instance
+  } as CliCommandInstance
   result.ui = presenterFactory.createCommandPresenter(result)
   if (result.commands) {
     result.commands = result.commands.map(c => createCommand(c, presenterFactory, { ...context, parent: result }))
@@ -18,7 +18,7 @@ export function createCommand(spec: Command, presenterFactory: PresenterFactory,
   return result
 }
 
-export function getCommand(args: string[], commands: Command.Instance[]): Command.Instance | undefined {
+export function getCommand(args: string[], commands: CliCommandInstance[]): CliCommandInstance | undefined {
   if (args.length === 0)
     return undefined
   const nameOrAlias = args.shift()!


### PR DESCRIPTION
Rename and Promote Command.Instance to CliCommandInstance as it is useful in consuming application.

Renamed because Command is too generic. Conflicting with the general Command pattern (although it is closely related).