### PR TITLE
feat: expose displayLevel directly.

### DIFF
--- a/src/Presenter.ts
+++ b/src/Presenter.ts
@@ -11,6 +11,11 @@ export interface CommandModel extends CliCommand.Base {
 }
 
 export interface LogPresenter {
+  displayLevel: DisplayLevel
+  /**
+   * Set display level.
+   * @deprecated use displayLevel directly
+   */
   setDisplayLevel(displayLevel: DisplayLevel): void
   info(...args: any[]): void
   warn(...args: any[]): void


### PR DESCRIPTION
It is needed to get eh displayLevel when user wants to have other sub-ui with matching displayLevel.