### PR TITLE
fix: improve setupCliCommandTest output type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![NPM version][npm-image]][npm-url]
 [![NPM downloads][downloads-image]][downloads-url]
-[![Build status][travis-image]][travis-url]
+
+[![CircleCI status][circleci-image]][circleci-url]
+[![Travis status][travis-image]][travis-url]
 [![Coverage Status][coveralls-image]][coveralls-url]
 
 [![Greenkeeper][greenkeeper-image]][greenkeeper-url]
@@ -180,6 +182,8 @@ npm run watch
 [npm-url]: https://npmjs.org/package/clibuilder
 [downloads-image]: https://img.shields.io/npm/dm/clibuilder.svg?style=flat
 [downloads-url]: https://npmjs.org/package/clibuilder
+[circleci-image]: https://circleci.com/gh/unional/clibuilder/tree/master.svg?style=shield
+[circleci-url]: https://circleci.com/gh/unional/clibuilder/tree/master
 [travis-image]: https://img.shields.io/travis/unional/clibuilder/master.svg?style=flat
 [travis-url]: https://travis-ci.org/unional/clibuilder?branch=master
 [coveralls-image]: https://coveralls.io/repos/github/unional/clibuilder/badge.svg

--- a/src/Cli.spec.ts
+++ b/src/Cli.spec.ts
@@ -80,6 +80,7 @@ test('support extending context', () => {
     commands: [{
       name: 'cmd',
       run() {
+        // `this.custom` does not report type error
         t.strictEqual(this.custom, true)
       }
     } as CliCommand<undefined, { custom: boolean }>]

--- a/src/CliCommand.ts
+++ b/src/CliCommand.ts
@@ -2,7 +2,6 @@ import { CliArgs } from './interfaces'
 import { LogPresenter, HelpPresenter, Inquirer } from './Presenter'
 
 export namespace CliCommand {
-
   export interface Base {
     name: string
     parent?: Base
@@ -79,15 +78,15 @@ export namespace CliCommand {
   }
 }
 
-export type CliCommandInstance<Config = {}, Context = {}> = {
+export interface CliCommandInstance<Config = {}, Context = {}> extends CliCommand.Base, CliCommand.Shared {
   cwd: string
   commands?: CliCommandInstance[]
   config?: Config
   ui: LogPresenter & HelpPresenter & Inquirer
   run(this: CliCommandInstance & Context & { config?: Config }, args: CliArgs, argv: string[]): void | Promise<any>
-} & CliCommand.Base & CliCommand.Shared & Context
+}
 
-export type CliCommand<Config = {}, Context = {}> = {
+export interface CliCommand<Config = {}, Context = {}> extends CliCommand.Shared {
   commands?: CliCommand[],
   run?: (this: CliCommandInstance & Context & { config?: Config }, args: CliArgs, argv: string[]) => void | Promise<any>
-} & CliCommand.Shared & Context
+}

--- a/src/CliCommand.ts
+++ b/src/CliCommand.ts
@@ -77,18 +77,17 @@ export namespace CliCommand {
     alias?: string[]
     ui?: LogPresenter & HelpPresenter & Inquirer
   }
-
 }
 
-export interface CliCommandInstance<Config = {}, Context = {}> extends CliCommand.Base, CliCommand.Shared {
+export type CliCommandInstance<Config = {}, Context = {}> = {
   cwd: string
   commands?: CliCommandInstance[]
   config?: Config
   ui: LogPresenter & HelpPresenter & Inquirer
   run(this: CliCommandInstance & Context & { config?: Config }, args: CliArgs, argv: string[]): void | Promise<any>
-}
+} & CliCommand.Base & CliCommand.Shared & Context
 
-export interface CliCommand<Config = {}, Context = {}> extends CliCommand.Shared {
+export type CliCommand<Config = {}, Context = {}> = {
   commands?: CliCommand[],
   run?: (this: CliCommandInstance & Context & { config?: Config }, args: CliArgs, argv: string[]) => void | Promise<any>
-}
+} & CliCommand.Shared & Context

--- a/src/test-util/setup.ts
+++ b/src/test-util/setup.ts
@@ -1,6 +1,6 @@
 import { Cli } from '../Cli';
 import {
-CliCommand,
+  CliCommand,
   // @ts-ignore
   CliCommandInstance
 } from '../CliCommand';
@@ -31,11 +31,11 @@ export function setupCliCommandTest<Config, Context = {}>(command: CliCommand<Co
 function createCliCommand<Config, Context = {}>(spec: CliCommand<Config, Context>, presenterFactory: PresenterFactory, context: {
   config?: Config,
   [index: string]: any
-}): CliCommandInstance<Config, Context> {
+}): CliCommandInstance<Config, Context> & Context {
   const result = {
     ...context,
     ...spec
-  } as CliCommandInstance<Config, Context>
+  } as CliCommandInstance<Config, Context> & Context
   result.ui = presenterFactory.createCommandPresenter(result)
   if (result.commands) {
     result.commands = result.commands.map(c => createCliCommand(c, presenterFactory, { ...context, parent: result }))


### PR DESCRIPTION
Make the test command also have access to the `context`