### PR TITLE
fix: adjust Cli and CliCommand type

### DIFF
--- a/src/Cli.spec.ts
+++ b/src/Cli.spec.ts
@@ -76,7 +76,7 @@ test('run nested command with argument', async () => {
 
 
 test('support extending context', () => {
-  const cli = new Cli<{ custom: boolean }>({
+  const cli = new Cli<undefined, { custom: boolean }>({
     name: 'cli',
     version: '1.2.1',
     commands: [{
@@ -130,7 +130,7 @@ test.skip('turn on debug-cli sets the log level to debug locally', async () => {
 
 test('read local json file', async () => {
   const o = new AssertOrder(1)
-  const cli = new Cli({
+  const cli = new Cli<{ a: number }>({
     name: 'test-cli',
     version: '0.0.1',
     commands: [{
@@ -139,7 +139,7 @@ test('read local json file', async () => {
         t.deepStrictEqual(this.config, { a: 1 })
         o.once(1)
       }
-    } as CliCommand<{ a: number }, {}>]
+    }]
   }, { cwd: 'fixtures/has-config' })
   await cli.parse(createCliArgv('cli', 'cfg'))
   o.end()

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -12,7 +12,7 @@ import { plainPresenterFactory } from './plainPresenterFactory';
 import { HelpPresenter, LogPresenter, VersionPresenter } from './Presenter';
 import yargs = require('yargs-parser')
 
-export interface CliOption<Config = any, Context = Record<string, any>> {
+export interface CliOption<Config, Context> {
   name: string
   version: string
   commands: CliCommand<Config, Context>[]
@@ -40,7 +40,7 @@ function overridePresenterFactory(context: Partial<CliContext> & Record<string, 
   return presenterFactory as any
 }
 
-export class Cli<Context extends { [i: string]: any } = {}> {
+export class Cli<Config extends Record<string, any> | undefined = undefined, Context extends Record<string, any> = {}> {
   // cwd: string
   options = {
     boolean: {
@@ -70,7 +70,7 @@ export class Cli<Context extends { [i: string]: any } = {}> {
   private ui: LogPresenter & HelpPresenter & VersionPresenter
   private presenterFactory: PresenterFactory
   private context: Partial<CliContext> & Context
-  constructor(option: CliOption<any, Context>, context: Partial<CliContext> & Context = {} as any) {
+  constructor(option: CliOption<Config, Context>, context: Partial<CliContext> & Context = {} as any) {
     this.name = option.name
     this.version = option.version
 
@@ -135,9 +135,9 @@ export class Cli<Context extends { [i: string]: any } = {}> {
   }
 }
 
-function getCmdChainCount(command: CliCommand.Base | undefined) {
+function getCmdChainCount(command: CliCommandInstance<any, any> | undefined) {
   let count = 0
-  let p = command
+  let p: any = command
   while (p) {
     p = p.parent
     count++

--- a/src/CliCommand.ts
+++ b/src/CliCommand.ts
@@ -74,13 +74,13 @@ export namespace CliCommand {
   }
 }
 
-export interface CliCommandInstance<Config, Context> extends CliCommand.Shared {
+export type CliCommandInstance<Config, Context> = CliCommand.Shared & Context & {
   cwd: string
   commands?: CliCommandInstance<any, any>[]
   config: Config
   parent: CliCommandInstance<Config, Context> | Cli<Config, Context>
   ui: LogPresenter & HelpPresenter & Inquirer
-  run(this: CliCommandInstance<Config, Context> & Context, args: CliArgs, argv: string[]): void | Promise<any>
+  run(this: CliCommandInstance<Config, Context>, args: CliArgs, argv: string[]): void | Promise<any>
 }
 
 export interface CliCommand<

--- a/src/CliCommand.ts
+++ b/src/CliCommand.ts
@@ -1,12 +1,8 @@
 import { CliArgs } from './interfaces'
 import { LogPresenter, HelpPresenter, Inquirer } from './Presenter'
+import { Cli } from './Cli';
 
 export namespace CliCommand {
-  export interface Base {
-    name: string
-    parent?: Base
-  }
-
   export interface Argument {
     name: string,
     description?: string
@@ -78,15 +74,19 @@ export namespace CliCommand {
   }
 }
 
-export interface CliCommandInstance<Config = any, Context = { [k: string]: any }> extends CliCommand.Base, CliCommand.Shared {
+export interface CliCommandInstance<Config, Context> extends CliCommand.Shared {
   cwd: string
-  commands?: CliCommandInstance[]
-  config?: Config
+  commands?: CliCommandInstance<any, any>[]
+  config: Config
+  parent: CliCommandInstance<Config, Context> | Cli<Config, Context>
   ui: LogPresenter & HelpPresenter & Inquirer
-  run(this: CliCommandInstance & Context & { config?: Config }, args: CliArgs, argv: string[]): void | Promise<any>
+  run(this: CliCommandInstance<Config, Context> & Context, args: CliArgs, argv: string[]): void | Promise<any>
 }
 
-export interface CliCommand<Config = any, Context extends Record<string, any> = Record<string, any>> extends CliCommand.Shared {
+export interface CliCommand<
+  Config extends Record<string, any> | undefined = undefined,
+  Context extends Record<string, any> = Record<string, any>
+  > extends CliCommand.Shared {
   commands?: CliCommand[],
-  run?: (this: CliCommandInstance & Context & { config?: Config }, args: CliArgs, argv: string[]) => void | Promise<any>
+  run?: (this: CliCommandInstance<Config, Context> & Context, args: CliArgs, argv: string[]) => void | Promise<any>
 }

--- a/src/Presenter.ts
+++ b/src/Presenter.ts
@@ -2,12 +2,14 @@ import inquirer = require('inquirer')
 import { CliCommand } from './CliCommand'
 import { DisplayLevel } from './Display'
 
-export interface CommandModel extends CliCommand.Base {
+export interface CommandModel {
+  name: string
   description?: string
   commands?: CommandModel[]
   arguments?: CliCommand.Argument[],
   alias?: string[]
-  options?: CliCommand.Options
+  options?: CliCommand.Options,
+  parent?: { name: string }
 }
 
 export interface LogPresenter {

--- a/src/commands/pluginsCommand.ts
+++ b/src/commands/pluginsCommand.ts
@@ -35,7 +35,7 @@ export const pluginsCommand = {
   commands: [list]
 } as CliCommand
 
-function getPluginCli(subject: CliCommandInstance | undefined): PluginCli | undefined {
+function getPluginCli<Config, Context>(subject: CliCommandInstance<Config, Context> | undefined): PluginCli | undefined {
   if (!subject) return undefined
   if (subject.parent && subject.parent instanceof PluginCli) return subject.parent
   return getPluginCli(subject.parent as any)

--- a/src/getCliCommand.ts
+++ b/src/getCliCommand.ts
@@ -1,6 +1,6 @@
 import { CliCommandInstance } from './CliCommand'
 
-export function getCliCommand<Config, Context>(args: string[], commands: CliCommandInstance[]): CliCommandInstance<Config, Context> | undefined {
+export function getCliCommand<Config, Context>(args: string[], commands: CliCommandInstance<Config, Context>[]): CliCommandInstance<Config, Context> | undefined {
   if (args.length === 0)
     return undefined
   const nameOrAlias = args.shift()!

--- a/src/test-util/getDisplay.ts
+++ b/src/test-util/getDisplay.ts
@@ -3,6 +3,6 @@ import { Cli } from '../Cli'
 
 import { InMemoryDisplay } from './InMemoryDisplay'
 
-export function getDisplay(subject: Cli | CliCommandInstance): InMemoryDisplay {
+export function getDisplay(subject: Cli | CliCommandInstance<any, any>): InMemoryDisplay {
   return (subject as any).ui.display
 }


### PR DESCRIPTION
BREAKING CHANGE: Cli takes two generics instead of one.