### PR TITLE
fix: CliCommandInstance.config can be undefined.

### DIFF
--- a/src/cli-command/CliCommand.spec.ts
+++ b/src/cli-command/CliCommand.spec.ts
@@ -29,7 +29,7 @@ test('this in run can access config', async () => {
   const { cmd, args, argv } = setupCliCommandTest({
     name: 'cmd',
     run() {
-      return Promise.resolve(this.config.a + this.context.b)
+      return Promise.resolve(this.config!.a + this.context.b)
     }
   }, [], { a: 'a' }, { b: 'b' })
 
@@ -188,7 +188,7 @@ test('config and context type is available within the run() context', async () =
   const { cmd, args, argv } = setupCliCommandTest({
     name: 'cmd',
     alias: ['c'],
-    run() { return Promise.resolve(`${this.config.a}.${this.context.b}`) }
+    run() { return Promise.resolve(`${this.config!.a}.${this.context.b}`) }
   }, [], { a: 'a' }, { b: 'b' })
   const actual = await cmd.run(args, argv)
   t.strictEqual(actual, 'a.b')

--- a/src/cli-command/CliCommand.ts
+++ b/src/cli-command/CliCommand.ts
@@ -76,7 +76,11 @@ export namespace CliCommand {
 
 export type CliCommandInstance<Config, Context> = CliCommand.Shared & {
   commands?: CliCommandInstance<Config, Context>[]
-  config: Config
+  /**
+   * Config object from <cli-name>.json.
+   * Can be undefined if there is no config file available.
+   */
+  config: Config | undefined
   context: Context
   parent: CliCommandInstance<Config, Context> | Cli<Config, Context>
   ui: LogPresenter & HelpPresenter & Inquirer


### PR DESCRIPTION
WHen there is no config file, `config` will be undefined.