### PR TITLE
fix: cli with args will invoke commands correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "search-packages": "^2.0.0",
     "standard-log": "^3.1.2",
     "standard-log-color": "^1.5.5",
-    "type-plus": "^1.28.0",
+    "type-plus": "^1.29.0",
     "wordwrap": "^1.0.0",
     "yargs-parser": "^10.1.0"
   },
@@ -67,6 +67,7 @@
     "@types/yargs-parser": "^11.0.3",
     "@unional/devpkg-node": "^1.4.0",
     "assertron": "^7.1.2",
+    "chalk": "^2.4.2",
     "clibuilder-plugin-dummy": "^1.0.1"
   }
 }

--- a/src/cli-command/getCliCommand.ts
+++ b/src/cli-command/getCliCommand.ts
@@ -6,8 +6,8 @@ export function getCliCommand<
   Context extends Record<string, any> = Record<string, any>>(
     args: string[],
     commands: CliCommand[]): CliCommandInstance<Config, CliContext & Context> | undefined {
-  if (args.length === 0)
-    return undefined
+  if (args.length === 0) return undefined
+
   const nameOrAlias = args.shift()!
   let matchedCommand
   commands.forEach(cmd => {

--- a/src/cli/Cli.spec.ts
+++ b/src/cli/Cli.spec.ts
@@ -1,11 +1,11 @@
 import a, { AssertOrder } from 'assertron';
+import { Answers } from 'inquirer';
 import { assertType, assignability } from 'type-plus';
-import { argCommand, createCliArgv, helloCommand, numberOptionCommand, InMemoryPresenter, InMemoryPresenterFactory, generateDisplayedMessage, echoCommand } from '../test-util';
-import { Cli, CliOptions } from './Cli';
-import { PresenterOption, PlainPresenter } from '../presenter';
 import { NoConfig } from '.';
 import { CliCommand } from '..';
-import { Answers } from 'inquirer';
+import { PlainPresenter, PresenterOption } from '../presenter';
+import { argCommand, createCliArgv, echoCommand, generateDisplayedMessage, helloCommand, InMemoryPresenter, InMemoryPresenterFactory, numberOptionCommand } from '../test-util';
+import { Cli, CliOptions } from './Cli';
 
 test('CliOptions requires either run() or commands', () => {
   assertType.isFalse(assignability<CliOptions<any, any>>()({
@@ -495,10 +495,25 @@ describe('Runable Cli', () => {
     await cli.parse(createCliArgv('cli'))
     o.end()
   })
+
+  test('invoke command if match', async () => {
+    const cli = new Cli({
+      name: 'cli',
+      version: '1.0.0',
+      commands: [helloCommand],
+      arguments: [{
+        name: 'first-arg',
+        required: true,
+      }],
+      async run() { throw new Error('should not reach') },
+    })
+
+    const actual = await cli.parse(createCliArgv('cli', 'hello'))
+    expect(actual).toEqual('hello')
+  })
 })
 
 test('can specify Config type and omit Context', () => {
-
   new Cli<{ a: 1 }>({
     name: 'cli',
     version: '1.0',

--- a/src/cli/Cli.ts
+++ b/src/cli/Cli.ts
@@ -1,4 +1,4 @@
-import { pick, RecursivePartial, required, requiredDeep } from 'type-plus';
+import { pick, RecursivePartial, required, requiredDeep, omit } from 'type-plus';
 import { CliArgs, parseArgv } from '../argv-parser';
 import { CliCommand, CliCommandInstance, createCliCommand, getCliCommand } from '../cli-command';
 import { log } from '../log';
@@ -79,21 +79,22 @@ export class Cli<Config, Context = unknown> {
   }
 
   parse(argv: string[]) {
-    const strippedArgv = argv.slice(1)
-    const args = parseArgv(this, strippedArgv)
-    return this.process(args, strippedArgv)
+    const argvWithoutNode = argv.slice(1)
+    return this.process(argvWithoutNode)
   }
 
   protected addCliCommand(command: CliCommand<Config, Context>) {
     this.commands.push(createCliCommand(command, this))
   }
 
-  private async process(args: CliArgs, argv: string[]): Promise<any> {
-    const command = getCliCommand(args._, this.commands)
+  private async process(argv: string[]): Promise<any> {
+    const commandArgs = parseArgv(omit(this, 'arguments'), argv)
+    const command = getCliCommand(commandArgs._, this.commands)
     if (command) {
-      return this.processCommand(command, args, argv)
+      return this.processCommand(command, commandArgs, argv)
     }
 
+    const args = parseArgv(this, argv)
     if (args.version) {
       this.ui.showVersion(this.version)
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4548,10 +4548,17 @@ type-name@^2.0.1:
   resolved "https://registry.yarnpkg.com/type-name/-/type-name-2.0.2.tgz#efe7d4123d8ac52afff7f40c7e4dec5266008fb4"
   integrity sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q=
 
-type-plus@^1.26.2, type-plus@^1.28.0:
+type-plus@^1.26.2:
   version "1.28.0"
   resolved "https://registry.yarnpkg.com/type-plus/-/type-plus-1.28.0.tgz#fd174c66cc943e5ac9b18be0c9204c5b8417c764"
   integrity sha512-BVhMS+vlICcvpL2D/7nwZq5mCBgMUkb3kOgdksQACdM6iBN2742S9TnZLDw6eWDvS9m8z6cJwAAQSlUd7TE73g==
+  dependencies:
+    unpartial "^0.6.3"
+
+type-plus@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/type-plus/-/type-plus-1.29.0.tgz#b4cd7b1a25151378f051ead678beb31bbf15ed9d"
+  integrity sha512-YwkR5pwuKHS6WuQMmng/6LvE4Y92ObV9OkCZYrUJ5ypHJuaKMS2EEy8octHHnVeNStpFebX+aYgyUcpTB2lGmg==
   dependencies:
     unpartial "^0.6.3"
 


### PR DESCRIPTION
The command name search take precedent over cli argument parsing