### PR TITLE
fix: allow unknown options and options with `-` and `_`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,37 @@ export const commandA: CliCommand = {
 }
 ```
 
+You can define arguments:
+
+```ts
+const commandA: CliCommand = {
+  name: 'command-a',
+  arguments: [{
+    name: 'arg1',
+    required: true
+  }]
+}
+```
+
+and/or options:
+
+```ts
+const commandB: CliCommand = {
+  name: 'command-b',
+  options: {
+    boolean: {
+      validate: { ... }
+    },
+    string: {
+      fileName: { ... }
+    },
+    number: {
+      maxSize: { ... }
+    }
+  }
+}
+```
+
 It comes with a plain presenter.
 You can override it to display your cli in any way you want:
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "standard-log-color": "^1.5.15",
     "type-plus": "^1.29.0",
     "wordwrap": "^1.0.0",
-    "yargs-parser": "^10.1.0"
+    "yargs-parser": "^16.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.2.0",

--- a/src/argv-parser/parseArgv.options.spec.ts
+++ b/src/argv-parser/parseArgv.options.spec.ts
@@ -1,5 +1,6 @@
 import t from 'assert'
-import { NotNumberOption } from '..'
+import a from 'assertron'
+import { NotNumberOption, InvalidOption } from '..'
 import { createParsable } from './createParsable'
 import { parseArgv } from './parseArgv'
 
@@ -120,12 +121,12 @@ test('options with wrong type will throws', () => {
   t.throws(() => parseArgv(cmd, ['a', '--numberOption=true']), NotNumberOption)
 })
 
-test('camelCase option is not expanded to hyphenated option', () => {
+test('do not support options with dash', () => {
   const cmd = createParsable({
     name: 'a',
     options: {
       string: {
-        specOutDir: {
+        'spec-out': {
           description: 'string',
           default: 'abc',
         },
@@ -134,5 +135,24 @@ test('camelCase option is not expanded to hyphenated option', () => {
     run() { return },
   }, {})
 
-  t.doesNotThrow(() => parseArgv(cmd, ['a']))
+  const err = a.throws(() => parseArgv(cmd, ['a']), InvalidOption)
+  expect(err.message).toBe(`Invalid option 'spec-out'. Recommend camel case.`)
+})
+
+test('do not support options with underscore', () => {
+  const cmd = createParsable({
+    name: 'a',
+    options: {
+      string: {
+        'spec_out': {
+          description: 'string',
+          default: 'abc',
+        },
+      },
+    },
+    run() { return },
+  }, {})
+
+  const err = a.throws(() => parseArgv(cmd, ['a']), InvalidOption)
+  expect(err.message).toBe(`Invalid option 'spec_out'. Recommend camel case.`)
 })

--- a/src/argv-parser/parseArgv.options.spec.ts
+++ b/src/argv-parser/parseArgv.options.spec.ts
@@ -1,25 +1,7 @@
 import t from 'assert'
-import a from 'assertron'
-import { NotNumberOption, InvalidOption } from '..'
+import { NotNumberOption } from '..'
 import { createParsable } from './createParsable'
 import { parseArgv } from './parseArgv'
-
-test('throw with unknown options', () => {
-  const cmd = createParsable({
-    name: 'a',
-    options: {
-      boolean: {
-        silent: {
-          description: 'silent',
-          alias: ['S'],
-        },
-      },
-    },
-    run() { return },
-  }, {})
-  const argv = ['a', '--something']
-  t.throws(() => parseArgv(cmd, argv))
-})
 
 const verboseWithAlias = {
   name: 'cmd',
@@ -119,40 +101,4 @@ test('options with wrong type will throws', () => {
     run() { return },
   }, {})
   t.throws(() => parseArgv(cmd, ['a', '--numberOption=true']), NotNumberOption)
-})
-
-test('do not support options with dash', () => {
-  const cmd = createParsable({
-    name: 'a',
-    options: {
-      string: {
-        'spec-out': {
-          description: 'string',
-          default: 'abc',
-        },
-      },
-    },
-    run() { return },
-  }, {})
-
-  const err = a.throws(() => parseArgv(cmd, ['a']), InvalidOption)
-  expect(err.message).toBe(`Invalid option 'spec-out'. Recommend camel case.`)
-})
-
-test('do not support options with underscore', () => {
-  const cmd = createParsable({
-    name: 'a',
-    options: {
-      string: {
-        'spec_out': {
-          description: 'string',
-          default: 'abc',
-        },
-      },
-    },
-    run() { return },
-  }, {})
-
-  const err = a.throws(() => parseArgv(cmd, ['a']), InvalidOption)
-  expect(err.message).toBe(`Invalid option 'spec_out'. Recommend camel case.`)
 })

--- a/src/argv-parser/parseArgv.ts
+++ b/src/argv-parser/parseArgv.ts
@@ -2,9 +2,9 @@ import { camelCase } from 'camel-case'
 import { filterKey } from 'type-plus'
 import yargs from 'yargs-parser'
 import { CliCommand } from '../cli-command'
-import { MissingArguments, NotNumberOption, TooManyArguments, UnknownOptionError, InvalidOption } from '../errors'
-import { CliArgs, CliArgsWithoutDefaults, Parsable } from './types'
+import { MissingArguments, NotNumberOption, TooManyArguments } from '../errors'
 import { toYargsOption } from './toYargsOption'
+import { CliArgs, CliArgsWithoutDefaults, Parsable } from './types'
 
 export function parseArgv(parsable: Parsable, rawArgv: string[]): CliArgs {
   const options = toYargsOption(parsable.options)
@@ -120,15 +120,11 @@ function validateOptions(command: Parsable, args: CliArgsWithoutDefaults) {
 
   Object.keys(args).forEach(name => {
     if (name === '_') return
-    if (name.indexOf('-') >= 0 || name.indexOf('_') >= 0) throw new InvalidOption(name)
     const optionType = map[name]
     if (optionType) {
       const arg = args[name]
       if (Number.isNaN(arg))
         throw new NotNumberOption(name)
-    }
-    else {
-      throw new UnknownOptionError(name)
     }
   })
 }

--- a/src/argv-parser/parseArgv.ts
+++ b/src/argv-parser/parseArgv.ts
@@ -2,7 +2,7 @@ import { camelCase } from 'camel-case'
 import { filterKey } from 'type-plus'
 import yargs from 'yargs-parser'
 import { CliCommand } from '../cli-command'
-import { MissingArguments, NotNumberOption, TooManyArguments, UnknownOptionError } from '../errors'
+import { MissingArguments, NotNumberOption, TooManyArguments, UnknownOptionError, InvalidOption } from '../errors'
 import { CliArgs, CliArgsWithoutDefaults, Parsable } from './types'
 import { toYargsOption } from './toYargsOption'
 
@@ -119,8 +119,8 @@ function validateOptions(command: Parsable, args: CliArgsWithoutDefaults) {
   }
 
   Object.keys(args).forEach(name => {
-    if (name === '_')
-      return
+    if (name === '_') return
+    if (name.indexOf('-') >= 0 || name.indexOf('_') >= 0) throw new InvalidOption(name)
     const optionType = map[name]
     if (optionType) {
       const arg = args[name]

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,20 +8,6 @@ export class NotNumberOption extends IsoError {
   }
 }
 
-export class InvalidOption extends IsoError {
-  constructor(public name: string) {
-    super(`Invalid option '${name}'. Recommend camel case.`)
-  }
-}
-
-export class UnknownOptionError extends IsoError {
-  // istanbul ignore next
-  constructor(public name: string) {
-    super(`Unknown option '${name}'`)
-    Object.setPrototypeOf(this, UnknownOptionError.prototype)
-  }
-}
-
 export class MissingArguments extends IsoError {
   // istanbul ignore next
   constructor(public expected: number, public actual: number) {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,6 +8,12 @@ export class NotNumberOption extends IsoError {
   }
 }
 
+export class InvalidOption extends IsoError {
+  constructor(public name: string) {
+    super(`Invalid option '${name}'. Recommend camel case.`)
+  }
+}
+
 export class UnknownOptionError extends IsoError {
   // istanbul ignore next
   constructor(public name: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1012,9 +1012,9 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
     color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.0.tgz#5681f0dcf7ae5880a7841d8831c4724ed9cc0172"
-  integrity sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
   dependencies:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
@@ -2123,7 +2123,7 @@ debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2137,7 +2137,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@^1.0.1:
+debuglog@*, debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -2245,6 +2245,11 @@ detect-indent@~5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
   integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
+
+detect-libc@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+  integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
 detect-newline@^2.1.0:
   version "2.1.0"
@@ -3475,7 +3480,7 @@ husky@^3.1.0:
     run-node "^1.0.0"
     slash "^3.0.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -3545,7 +3550,7 @@ import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@^0.1.4:
+imurmurhash@*, imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -4856,6 +4861,11 @@ lockfile@^1.0.4:
   dependencies:
     signal-exit "^3.0.2"
 
+lodash._baseindexof@*:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
+  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
+
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -4864,10 +4874,32 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
+lodash._bindcallback@*:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
+  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
+
+lodash._cacheindexof@*:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
+  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
+
+lodash._createcache@*:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
+  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
+  dependencies:
+    lodash._getnative "^3.0.0"
+
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
+
+lodash._getnative@*, lodash._getnative@^3.0.0:
+  version "3.9.1"
+  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
+  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -4918,6 +4950,11 @@ lodash.memoize@4.x:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
+
+lodash.restparam@*:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
+  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -5381,6 +5418,15 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+needle@^2.2.1:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-2.4.0.tgz#6833e74975c444642590e15a750288c5f939b57c"
+  integrity sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==
+  dependencies:
+    debug "^3.2.6"
+    iconv-lite "^0.4.4"
+    sax "^1.2.4"
+
 neo-async@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
@@ -5462,6 +5508,22 @@ node-notifier@^5.4.2:
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+node-pre-gyp@*:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
 
 nopt@^4.0.1, nopt@~4.0.1:
   version "4.0.1"
@@ -5559,7 +5621,7 @@ npm-normalize-package-bin@^1.0.0, npm-normalize-package-bin@^1.0.1:
     semver "^5.6.0"
     validate-npm-package-name "^3.0.0"
 
-npm-packlist@^1.1.12, npm-packlist@^1.4.7:
+npm-packlist@^1.1.12, npm-packlist@^1.1.6, npm-packlist@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/npm-packlist/-/npm-packlist-1.4.7.tgz#9e954365a06b80b18111ea900945af4f88ed4848"
   integrity sha512-vAj7dIkp5NhieaGZxBJB8fF4R0078rqsmhJcAfXZ6O7JJhjhPK96n5Ry1oZcfLXgfun0GWTZPOxaEyqv8GBykQ==
@@ -5738,7 +5800,7 @@ npm@^6.10.3:
     worker-farm "^1.7.0"
     write-file-atomic "^2.4.3"
 
-npmlog@^4.1.2, npmlog@~4.1.2:
+npmlog@^4.0.2, npmlog@^4.1.2, npmlog@~4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
   integrity sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
@@ -5950,9 +6012,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0, p-limit@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.1.tgz#aa07a788cc3151c939b5131f63570f0dd2009537"
-  integrity sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
   dependencies:
     p-try "^2.0.0"
 
@@ -6498,7 +6560,7 @@ qw@~1.0.1:
   resolved "https://registry.yarnpkg.com/qw/-/qw-1.0.1.tgz#efbfdc740f9ad054304426acb183412cc8b996d4"
   integrity sha1-77/cdA+a0FQwRCassYNBLMi5ltQ=
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
+rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -6898,7 +6960,7 @@ rimraf@2.6.3, rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
+rimraf@^2.5.2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3, rimraf@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
@@ -7044,7 +7106,7 @@ semver-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-2.0.0.tgz#a93c2c5844539a770233379107b38c7b4ac9d338"
   integrity sha512-mUdIBBvdn0PLOeP3TEkMH7HHeUP3GjsXCwKarjv/kGmUFOYg1VqEemKhoQpWMu6X2I8kHeuVdGibLGkVK+/5Qw==
 
-"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -7624,7 +7686,7 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
-tar@^4.4.10, tar@^4.4.12, tar@^4.4.13:
+tar@^4.4.10, tar@^4.4.12, tar@^4.4.13, tar@^4.4.2:
   version "4.4.13"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
   integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
@@ -8384,7 +8446,7 @@ yaml@^1.7.2:
   dependencies:
     "@babel/runtime" "^7.6.3"
 
-yargs-parser@10.x, yargs-parser@^10.0.0, yargs-parser@^10.1.0:
+yargs-parser@10.x, yargs-parser@^10.0.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
   integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==


### PR DESCRIPTION
Originally I disallow this to make the system more concise.
But I changed my mind to make the system more flexible instead.

author can create conflicting options with this change (which was what I tried to avoid):

```ts
{
  options: {
    string: {
      someKey: { ... },
      'some-key': { ... }
    }
  }
}
```

But now rely on the author to not doing this instead.