### PR TITLE
fix: improve command type

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,20 +231,35 @@ createCli({
 })
 ```
 
-When using `config` and `context`,
+When using `Config` and `Context`,
 you can specify their type using `createCommand<Config, Context>()`.
 
 Due to TypeScript limitation,
 when explicitly specifying the `Config` or `Context` type,
 you lost the the ability to infer types from `Argument` and `Options`.
 
+instead, you can specify the `config` property and `context` property directly.
+Note that the value in the `config` property is not being used.
+It is only for defining the shape of the config that the command expects.
+
 ```ts
-const cmd = createCommand<{ a: number }, { b: string }>({
+createCommand<{ a: number }, { b: string }>({
   arguments: [{ name: 'arg' }],
   run(args) {
-    args.arg as unknown as string// typed as never
+    args.otherArgs as unknown as string// typed as never
     this.config.a // number
     this.b // string
+  }
+})
+
+// perferred
+createCommand({
+  config: { a: 1 },
+  context: { b: 'b' },
+  arguments: [{ name: 'arg' }],
+  run(args) {
+    this.config.a // number
+    this.b // = 'b'
   }
 })
 ```

--- a/src/cli/createCli.ts
+++ b/src/cli/createCli.ts
@@ -201,9 +201,9 @@ function validateCliCommand(cmd: Cli.Command<any, any>) {
   validateOptions(cmd)
 }
 
-function validateArgument(cmd: Cli.Command<any, any>) {
-  const args = cmd.arguments
-  if (args) {
+function validateArgument(cmd: Cli.Command) {
+  if (hasProperty(cmd, 'run') && cmd.arguments) {
+    const args = cmd.arguments
     const multiIndex = args.findIndex(arg => arg.multiple === true)
     if (multiIndex !== -1 && multiIndex !== args.length - 1) {
       throw new MultipleArgumentNotLastEntry(cmd.name, args[multiIndex].name)
@@ -212,8 +212,8 @@ function validateArgument(cmd: Cli.Command<any, any>) {
 }
 
 function validateOptions(cmd: Cli.Command<any, any>) {
-  const options = cmd.options
-  if (options) {
+  if (hasProperty(cmd, 'run') && cmd.options) {
+    const options = cmd.options
     const strOptionNames = options.string ? Object.keys(options.string) : []
     const numOptionNames = options.number ? Object.keys(options.number) : []
     const boolOptionNames = options.boolean ? Object.keys(options.boolean) : []

--- a/src/cli/types.ts
+++ b/src/cli/types.ts
@@ -75,11 +75,26 @@ export namespace Cli {
     O extends Options<BName, SName, NName> = Options<BName, SName, NName>
     > = {
       name: string,
+    } & ({
       description: string,
+      /**
+       * The config this command is expecting.
+       * The value in this property is not actively used.
+       * It is used to define the shape of the config.
+       * Defining this property has the same effect as specifying the generic type `Config`,
+       * but still keep the type inference working.
+       */
+      config?: Config,
+      /**
+       * A context that the the command will receive at `this`.
+       * Use this for dependency injection,
+       * and specifying the shape of the context,
+       * like the `config` property.
+       */
+      context?: Context,
       arguments?: Argument<AName>[],
       options?: O,
       alias?: string[],
-    } & ({
       commands?: Command<Config, Context>[],
       run(this: RunContext<Config, Context>, args: RunArgs<AName, BName, SName, NName, O>, argv: string[]): Promise<any> | any,
     } | {

--- a/src/plugin-cli/loadPlugins.ts
+++ b/src/plugin-cli/loadPlugins.ts
@@ -74,7 +74,7 @@ function isValidPlugin(m: any) {
 }
 
 function activatePlugin(m: { activate: (context: PluginCli.ActivationContext) => void }) {
-  const commands: PluginCli.Command<any, any>[] = []
+  const commands: PluginCli.Command[] = []
   m.activate({ addCommand: cmd => commands.push(cmd) })
   return commands
 }

--- a/src/plugin-cli/searchPackageCommand.ts
+++ b/src/plugin-cli/searchPackageCommand.ts
@@ -2,9 +2,10 @@ import { searchByKeywords } from 'search-packages'
 import { required } from 'type-plus'
 import { createPluginCommand } from './createPluginCommand'
 
-export const searchPackageCommand = createPluginCommand<never, { _dep: { searchByKeywords: typeof searchByKeywords } }>({
+export const searchPackageCommand = createPluginCommand({
   name: 'search',
   description: 'search for npm packages by keywords',
+  context: { _dep: { searchByKeywords } },
   arguments: [{
     name: 'keywords',
     required: true,

--- a/src/plugin-cli/searchPluginsCommand.ts
+++ b/src/plugin-cli/searchPluginsCommand.ts
@@ -2,12 +2,11 @@ import { searchByKeywords } from 'search-packages'
 import { required } from 'type-plus'
 import { createPluginCommand } from './createPluginCommand'
 
-export const searchPluginsCommand = createPluginCommand<never, { _dep: { searchByKeywords: typeof searchByKeywords } }>({
+export const searchPluginsCommand = createPluginCommand({
   name: 'search',
   description: 'Search online for available plugins',
-  arguments: [{ name: 'adf' }],
-  async run(args) {
-    args.asdf
+  context: { _dep: { searchByKeywords } },
+  async run() {
     if (!this.keyword) {
       this.ui.error('plugins search command can only be used by PluginCli')
       return

--- a/src/plugin-cli/types.ts
+++ b/src/plugin-cli/types.ts
@@ -42,11 +42,29 @@ export namespace PluginCli {
     O extends Cli.Options<BName, SName, NName> = Cli.Options<BName, SName, NName>
     > = {
       name: string,
+    } & ({
       description: string,
+      /**
+       * The config this command is expecting.
+       * The value in this property is not actively used.
+       * It is used to define the shape of the config.
+       * Defining this property has the same effect as specifying the generic type `Config`,
+       * but still keep the type inference working.
+       */
+      config?: Config,
+      /**
+       * A context that the the command will receive at `this`.
+       * Use this for dependency injection,
+       * and specifying the shape of the context,
+       * like the `config` property.
+       */
+      context?: Context,
       arguments?: Cli.Argument<AName>[],
       options?: O,
       alias?: string[],
       commands?: Command<Config, Context>[],
-      run?(this: Cli.RunContext<Config, Context & { keyword: string }>, args: Cli.RunArgs<AName, BName, SName, NName, O>, argv: string[]): Promise<any> | any,
-    }
+      run(this: Cli.RunContext<Config, Context & { keyword: string }>, args: Cli.RunArgs<AName, BName, SName, NName, O>, argv: string[]): Promise<any> | any,
+    } | {
+      commands?: Command<Config, Context>[],
+    })
 }


### PR DESCRIPTION
Now you can define the `config` and `context` property for command.

And the type shape is improved.