### PR TITLE
fix: not throwing when there are errors

### DIFF
--- a/src/create-cli/createCli.spec.ts
+++ b/src/create-cli/createCli.spec.ts
@@ -62,7 +62,7 @@ test('-v shows version', async () => {
     description: '',
     run() { }
   }, '-v')
-  await cli.parse(argv);
+  await cli.parse(argv)
   const message = generateDisplayedMessage(ui.display.infoLogs)
   expect(message).toBe('1.0.0')
 })
@@ -72,7 +72,7 @@ test('--version shows version', async () => {
     description: '',
     run() { }
   }, '--version')
-  await cli.parse(argv);
+  await cli.parse(argv)
   const message = generateDisplayedMessage(ui.display.infoLogs)
   expect(message).toBe('1.0.0')
 })
@@ -94,7 +94,7 @@ test('-h shows help', async () => {
     description: 'test cli',
     run() { }
   }, '-h')
-  await cli.parse(argv);
+  await cli.parse(argv)
   const message = generateDisplayedMessage(ui.display.infoLogs)
   expect(message).toBe(runnableCliHelpMessage)
 })
@@ -104,7 +104,7 @@ test('--help shows help', async () => {
     description: 'test cli',
     run() { }
   }, '--help')
-  await cli.parse(argv);
+  await cli.parse(argv)
   const message = generateDisplayedMessage(ui.display.infoLogs)
   expect(message).toBe(runnableCliHelpMessage)
 })
@@ -324,7 +324,7 @@ describe('cli without command', () => {
       }
     })
 
-    await a.throws(cli.parse(argv))
+    await cli.parse(argv)
 
     const msg = generateDisplayedMessage(ui.display.errorLogs)
 
@@ -338,7 +338,7 @@ describe('cli without command', () => {
       }
     })
 
-    await a.throws(cli.parse(argv))
+    await cli.parse(argv)
 
     const msg = generateDisplayedMessage(ui.display.errorLogs)
 
@@ -521,23 +521,21 @@ describe('cli with commands', () => {
     expect(actual).toBe(3)
   })
 
-  test('command throws will throw the error at cli level', async () => {
+  test('command throws is captured in error logs', async () => {
     const { cli, argv, ui } = createCliTest({ commands: [throwCommand] }, 'throw', 'some error')
 
-    const err = await a.throws(cli.parse(argv))
+    await cli.parse(argv)
 
     const msg = generateDisplayedMessage(ui.display.errorLogs)
-    expect(err.message).toEqual('some error')
     expect(msg).toEqual('command throw throws: Error: some error')
   })
 
-  test('command reject will throw the error at cli level', async () => {
+  test('command reject is captured in error logs', async () => {
     const { cli, argv, ui } = createCliTest({ commands: [rejectCommand] }, 'reject', 'some error')
 
-    const err = await a.throws(cli.parse(argv))
+    await cli.parse(argv)
 
     const msg = generateDisplayedMessage(ui.display.errorLogs)
-    expect(err.message).toEqual('some error')
     expect(msg).toEqual('command reject throws: Error: some error')
   })
 
@@ -637,7 +635,7 @@ describe('config', () => {
 
     await cli.parse(argv)
   })
-});
+})
 
 test('exit with specific error code for cli run()', async () => {
   const { argv, cli } = createCliTest({
@@ -662,4 +660,31 @@ test('exit with specific error code for cmd run()', async () => {
   await cli.parse(argv)
 
   expect(process.exitCode).toBe(3)
+})
+
+test('missing required argument', async () => {
+  // const { cli, argv } = createCliTest({
+  //   arguments: [{
+  //     name: 'a',
+  //     required: true
+  //   }],
+  //   run(args) {
+  //     this.ui.info(args.a)
+  //   }
+  // })
+  const { cli, argv } = createCliTest({
+    commands: [{
+      name: 'x',
+      description: 'x',
+      arguments: [{
+        name: 'a',
+        required: true
+      }],
+      run(args) {
+        this.ui.info(args.a)
+      }
+    }]
+  }, 'x')
+
+  await cli.parse(argv)
 })

--- a/src/create-cli/createCli.ts
+++ b/src/create-cli/createCli.ts
@@ -27,7 +27,17 @@ export function createCli<
     version: opts.version,
     async parse(argv: string[]) {
       const argvWithoutNode = argv.slice(1)
-      const args = parseArgv(opts, argvWithoutNode)
+
+      let args
+      try {
+        args = parseArgv(opts, argvWithoutNode)
+      }
+      catch (e) {
+        ui.error(e.message)
+        ui.showHelp(opts)
+        return
+      }
+
 
       const [trimmedArgs, trimmedArgv] = removeCliLevelOptions(args, argvWithoutNode)
 
@@ -54,7 +64,7 @@ export function createCli<
         catch (e) {
           ui.error(e.message)
           ui.showHelp(command)
-          throw e
+          return
         }
 
         try {
@@ -67,7 +77,7 @@ export function createCli<
             return
           }
           ui.error(`command ${command.name} throws: ${e}`)
-          throw e
+          return
         }
       }
 
@@ -87,7 +97,7 @@ export function createCli<
             return
           }
           ui.error(`${cli.name} throws: ${e}`)
-          throw e
+          return
         }
       }
 

--- a/src/create-plugin-cli/searchPackageCommand.spec.ts
+++ b/src/create-plugin-cli/searchPackageCommand.spec.ts
@@ -1,6 +1,4 @@
 import t from 'assert'
-import a from 'assertron'
-import { MissingArguments } from '../errors'
 import { createCliTest, createPluginCliTest, generateDisplayedMessage } from '../test-util'
 import { searchPackageCommand } from './searchPackageCommand'
 
@@ -18,7 +16,7 @@ test('can only be used by PluginCli', async () => {
 test('requires at least one keyword', async () => {
   const { cli, argv, ui } = createPluginCliTest({ commands: [searchPackageCommand] }, 'search')
 
-  await a.throws(cli.parse(argv), MissingArguments)
+  await cli.parse(argv)
 
   const message = generateDisplayedMessage(ui.display.errorLogs)
   t.strictEqual(message, `Missing Argument. Expecting 1 but received 0.`)

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,7 +1,6 @@
 import t from 'assert'
 import a from 'assertron'
 import { argCommand, booleanOptionsCommand, echoCommand, echoNameOptionCommand, errorCommand, generateDisplayedMessage, groupOptionsCommand, noopCommand, verboseCommand } from '.'
-import { MissingArguments } from './errors'
 import { createCliTest, echoCommandHelpMessage, echoDebugCommand } from './test-util'
 
 const noopHelpMessage = `
@@ -185,7 +184,7 @@ when called with 'arg'
 then show report missing argument`, async () => {
   const { cli, argv, ui } = createCliTest({ commands: [argCommand] }, 'arg')
 
-  await a.throws(cli.parse(argv), MissingArguments)
+  await cli.parse(argv)
 
   const actual = generateDisplayedMessage(ui.display.errorLogs)
   t.strictEqual(actual, 'Missing Argument. Expecting 1 but received 0.')


### PR DESCRIPTION

Throwing error is useful when the code is used as api,
but makes cli hard to use.