### PR TITLE
fix: replace instanceof check

### DIFF
--- a/src/ui.ts
+++ b/src/ui.ts
@@ -4,6 +4,7 @@ import { someKey } from 'type-plus'
 import wordwrap from 'wordwrap'
 import * as z from 'zod'
 import type { cli } from './cli'
+import { isZodArray, isZodNumber, isZodOptional, isZodString } from './zod'
 
 const INDENT = 2
 const RIGHT_PADDING = 2
@@ -204,13 +205,13 @@ function formatKeyValue(key: string, value: cli.Command.Options.Entry) {
 
 function formatOptionSignature(zodType: z.ZodTypeAny | undefined, keys: string) {
   if (!zodType) return `[${keys}]`
-  const optional = zodType instanceof z.ZodOptional
+  const optional = isZodOptional(zodType)
   const t = optional ? zodType._def.innerType : zodType
-  const isArray = t instanceof z.ZodArray
+  const isArray = isZodArray(t)
   const at = isArray ? t.element : t
-  const valueType = at instanceof z.ZodString
+  const valueType = isZodString(at)
     ? isArray ? '=string...' : '=string'
-    : at instanceof z.ZodNumber
+    : isZodNumber(at)
       ? isArray ? '=number...' : '=number'
       : isArray ? '=boolean...' : ''
 
@@ -220,7 +221,7 @@ function formatOptionSignature(zodType: z.ZodTypeAny | undefined, keys: string) 
 }
 
 function formatDescription(value: cli.Command.Options.Entry) {
-  const d = value.type instanceof z.ZodString ? `'${value.default}'` : value.default
+  const d = value.type && isZodString(value.type) ? `'${value.default}'` : value.default
   return value.default ? `${value.description} (default ${d})` : value.description
 }
 function generateAliasSection(command: createUI.Command) {

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,1 +1,26 @@
-export * as z from 'zod'
+import * as z from 'zod'
+export { z }
+
+export function isZodArray(type: z.ZodAny | undefined): type is z.ZodArray<any> {
+  return type && (type as any).element
+}
+
+export function isZodOptional(type: z.ZodAny | undefined): type is z.ZodOptional<any> {
+  return !!type && type.isOptional()
+}
+
+export function isZodBoolean(type: z.ZodAny | undefined): type is z.ZodBoolean {
+  return isZodType(type, 'ZodBoolean')
+}
+
+export function isZodNumber(type: z.ZodAny | undefined): type is z.ZodBoolean {
+  return isZodType(type, 'ZodNumber')
+}
+
+export function isZodString(type: z.ZodAny | undefined): type is z.ZodString {
+  return isZodType(type, 'ZodString')
+}
+
+function isZodType(type: z.ZodAny | undefined, name: string) {
+  return Object.getPrototypeOf(type).constructor.name === name
+}


### PR DESCRIPTION
instanceof check does not work in plugin environment.

Because in NodeJS,
the plugin can be using its own copy of the zod library,
under its own node_modules.

This cause all instanceof check to fail.

Need to rely of other mechanism to detect the type.