### PR TITLE
fix(clibuilder): export types

### DIFF
--- a/.changeset/commit.cjs
+++ b/.changeset/commit.cjs
@@ -1,0 +1,9 @@
+const commit = require('@changesets/cli/commit')
+
+module.exports = {
+  async getAddMessage(changeset, options) {
+    const skipCI = options?.skipCI === "add" || options?.skipCI === true;
+    return `${changeset.summary}${skipCI ? `\n\n[skip ci]\n` : ""}`;
+  },
+  getVersionMessage: commit.default.getVersionMessage
+}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,12 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@2.1.1/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": false,
+  "commit": [
+    "./commit.cjs",
+    {
+      "skipCI": "version"
+    }
+  ],
   "fixed": [],
   "linked": [],
   "access": "public",

--- a/.changeset/swift-cougars-remain.md
+++ b/.changeset/swift-cougars-remain.md
@@ -1,0 +1,7 @@
+---
+"clibuilder": patch
+---
+
+fix(clibuilder): export types
+
+The top-level `typings` field is not picked up by ESM use case.

--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -27,15 +27,16 @@
   "exports": {
     ".": {
       "import": "./libm/index.js",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "types": "./lib/index.d.ts"
     }
   },
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "./lib/index.js",
+  "typings": "./lib/index.d.ts",
   "files": [
     "lib",
     "libm",
-    "src"
+    "ts"
   ],
   "scripts": {
     "build": "yarn build:libm && yarn build:lib",


### PR DESCRIPTION
The top-level `typings` field is not picked up by ESM use case.