### PR TITLE
chore: update deps and modernize clibuilder internals

### DIFF
--- a/.changeset/tame-rockets-relax.md
+++ b/.changeset/tame-rockets-relax.md
@@ -1,0 +1,5 @@
+---
+"clibuilder": patch
+---
+
+Update dependencies (find-installed-packages, tmp, ts-jest, npm-run-all2, rimraf) and modernize internals: replace `.then()` chains with async/await in `builder.ts` and `plugins.ts`, bump `engines.node` to reflect actual ESM support.

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
 	"extends": ["@repobuddy/biome/recommended"],
 	"files": {
 		"includes": ["!**/.pnpm-store", "!**/cjs", "!**/coverage", "!**/esm", "!**/target", "!**/node_modules"]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"version": "changeset version"
 	},
 	"devDependencies": {
-		"@biomejs/biome": "^2.4.14",
+		"@biomejs/biome": "^2.5.2",
 		"@changesets/cli": "^2.31.0",
 		"@commitlint/cli": "^20.5.3",
 		"@commitlint/config-conventional": "^20.5.3",
@@ -32,7 +32,7 @@
 		"@types/node": "^24.12.2",
 		"husky": "^9.0.11",
 		"npm-run-all2": "^8.0.4",
-		"turbo": "^2.9.8"
+		"turbo": "^2.10.3"
 	},
 	"packageManager": "pnpm@10.33.2"
 }

--- a/packages/args-minus/package.json
+++ b/packages/args-minus/package.json
@@ -58,9 +58,9 @@
 		"jest-watch-suspend": "^1.1.2",
 		"jest-watch-toggle-config-2": "^2.1.0",
 		"jest-watch-typeahead": "^2.2.2",
-		"npm-run-all2": "^6.0.0",
-		"rimraf": "^5.0.0",
-		"ts-jest": "^29.1.0",
+		"npm-run-all2": "^6.2.6",
+		"rimraf": "^5.0.10",
+		"ts-jest": "^29.4.11",
 		"type-plus": "^7.0.0",
 		"typescript": "^5.0.4"
 	},

--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -54,14 +54,14 @@
 		"w": "pnpm watch"
 	},
 	"dependencies": {
-		"find-installed-packages": "^3.0.3",
+		"find-installed-packages": "^3.1.1",
 		"find-up": "^7.0.0",
 		"js-yaml": "^4.1.1",
 		"pad-right": "^0.2.2",
 		"search-packages": "^2.1.0",
 		"standard-log": "^12.1.1",
 		"standard-log-color": "^12.1.1",
-		"tmp": "^0.2.5",
+		"tmp": "^0.2.7",
 		"tslib": "^2.5.0",
 		"type-plus": "^7.0.0",
 		"wordwrap": "^1.0.0",
@@ -88,16 +88,16 @@
 		"jest-watch-toggle-config-2": "^2.1.0",
 		"jest-watch-typeahead": "^2.2.2",
 		"ncp": "^2.0.0",
-		"npm-run-all2": "^6.0.0",
+		"npm-run-all2": "^6.2.6",
 		"path-equal": "^1.2.5",
 		"plugin-two": "workspace:*",
-		"rimraf": "^5.0.0",
+		"rimraf": "^5.0.10",
 		"tersify": "^3.12.1",
-		"ts-jest": "^29.1.0",
+		"ts-jest": "^29.4.11",
 		"tslib": "^2.5.0",
 		"typescript": "^5.0.4"
 	},
 	"engines": {
-		"node": ">= 8"
+		"node": ">= 18"
 	}
 }

--- a/packages/clibuilder/ts/builder.ts
+++ b/packages/clibuilder/ts/builder.ts
@@ -27,14 +27,14 @@ export function builder(context: Context, options: cli.Options): cli.Builder & c
 
 	if (loadingConfig) {
 		pending.push(
-			loadingConfig.then((config) => {
+			(async () => {
+				const config = await loadingConfig
 				s.config = config
 				if (config?.plugins) {
-					return context
-						.loadPlugins(config.plugins)
-						.then((commands) => s.command.commands.push(...commands.map((c) => adjustCommand(s.command, c))))
+					const commands = await context.loadPlugins(config.plugins)
+					s.command.commands.push(...commands.map((c) => adjustCommand(s.command, c)))
 				}
-			})
+			})()
 		)
 	}
 	return {

--- a/packages/clibuilder/ts/plugins.ts
+++ b/packages/clibuilder/ts/plugins.ts
@@ -7,12 +7,10 @@ export async function loadPlugins({ cwd, ui }: { cwd: string; ui: createUI.UI },
 
 async function activatePlugins(cwd: string, ui: createUI.UI, pluginNames: string[]) {
 	const entries = await Promise.all(
-		pluginNames.map((name) => {
+		pluginNames.map(async (name) => {
 			ui.debug('loading plugin', name)
-			return loadModule(cwd, ui, name).then((pluginModule) => ({
-				name,
-				pluginModule
-			}))
+			const pluginModule = await loadModule(cwd, ui, name)
+			return { name, pluginModule }
 		})
 	)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.4.14
-        version: 2.4.14
+        specifier: ^2.5.2
+        version: 2.5.2
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@24.12.2)
@@ -22,7 +22,7 @@ importers:
         version: 20.5.3
       '@repobuddy/biome':
         specifier: ^2.3.1
-        version: 2.3.1(@biomejs/biome@2.4.14)
+        version: 2.3.1(@biomejs/biome@2.5.2)
       '@types/node':
         specifier: ^24.12.2
         version: 24.12.2
@@ -33,14 +33,14 @@ importers:
         specifier: ^8.0.4
         version: 8.0.4
       turbo:
-        specifier: ^2.9.8
-        version: 2.9.8
+        specifier: ^2.10.3
+        version: 2.10.3
 
   packages/args-minus:
     devDependencies:
       '@repobuddy/jest':
         specifier: ^3.3.0
-        version: 3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@24.12.2)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@24.12.2)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@24.12.2)))(jest@29.7.0(@types/node@24.12.2))(ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3))
+        version: 3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@24.12.2)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@24.12.2)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@24.12.2)))(jest@29.7.0(@types/node@24.12.2))(ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3))
       '@repobuddy/typescript':
         specifier: ^2.0.0
         version: 2.1.0
@@ -63,14 +63,14 @@ importers:
         specifier: ^2.2.2
         version: 2.2.2(jest@29.7.0(@types/node@24.12.2))
       npm-run-all2:
-        specifier: ^6.0.0
+        specifier: ^6.2.6
         version: 6.2.6
       rimraf:
-        specifier: ^5.0.0
+        specifier: ^5.0.10
         version: 5.0.10
       ts-jest:
-        specifier: ^29.1.0
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3)
+        specifier: ^29.4.11
+        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3)
       type-plus:
         specifier: ^7.0.0
         version: 7.6.2
@@ -81,8 +81,8 @@ importers:
   packages/clibuilder:
     dependencies:
       find-installed-packages:
-        specifier: ^3.0.3
-        version: 3.0.3
+        specifier: ^3.1.1
+        version: 3.1.1
       find-up:
         specifier: ^7.0.0
         version: 7.0.0
@@ -102,8 +102,8 @@ importers:
         specifier: ^12.1.1
         version: 12.1.2(standard-log@12.1.2)
       tmp:
-        specifier: ^0.2.5
-        version: 0.2.5
+        specifier: ^0.2.7
+        version: 0.2.7
       tslib:
         specifier: ^2.5.0
         version: 2.8.1
@@ -119,7 +119,7 @@ importers:
     devDependencies:
       '@repobuddy/jest':
         specifier: ^3.3.0
-        version: 3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@25.6.0)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@25.6.0)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@25.6.0)))(jest@29.7.0(@types/node@25.6.0))(ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.6.0))(typescript@5.9.3))
+        version: 3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@26.1.0)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@26.1.0)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@26.1.0)))(jest@29.7.0(@types/node@26.1.0))(ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.0))(typescript@5.9.3))
       '@types/jest':
         specifier: ^29.5.1
         version: 29.5.14
@@ -164,21 +164,21 @@ importers:
         version: link:../../test-plugins/esm-plugin
       jest:
         specifier: ^29.5.0
-        version: 29.7.0(@types/node@25.6.0)
+        version: 29.7.0(@types/node@26.1.0)
       jest-watch-suspend:
         specifier: ^1.1.2
-        version: 1.1.2(jest@29.7.0(@types/node@25.6.0))
+        version: 1.1.2(jest@29.7.0(@types/node@26.1.0))
       jest-watch-toggle-config-2:
         specifier: ^2.1.0
-        version: 2.1.0(jest@29.7.0(@types/node@25.6.0))
+        version: 2.1.0(jest@29.7.0(@types/node@26.1.0))
       jest-watch-typeahead:
         specifier: ^2.2.2
-        version: 2.2.2(jest@29.7.0(@types/node@25.6.0))
+        version: 2.2.2(jest@29.7.0(@types/node@26.1.0))
       ncp:
         specifier: ^2.0.0
         version: 2.0.0
       npm-run-all2:
-        specifier: ^6.0.0
+        specifier: ^6.2.6
         version: 6.2.6
       path-equal:
         specifier: ^1.2.5
@@ -187,14 +187,14 @@ importers:
         specifier: workspace:*
         version: link:../../test-plugins/plugin-two
       rimraf:
-        specifier: ^5.0.0
+        specifier: ^5.0.10
         version: 5.0.10
       tersify:
         specifier: ^3.12.1
         version: 3.12.1
       ts-jest:
-        specifier: ^29.1.0
-        version: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.6.0))(typescript@5.9.3)
+        specifier: ^29.4.11
+        version: 29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.0))(typescript@5.9.3)
       typescript:
         specifier: ^5.0.4
         version: 5.9.3
@@ -674,59 +674,59 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@biomejs/biome@2.4.14':
-    resolution: {integrity: sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==}
+  '@biomejs/biome@2.5.2':
+    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.14':
-    resolution: {integrity: sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==}
+  '@biomejs/cli-darwin-arm64@2.5.2':
+    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.14':
-    resolution: {integrity: sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==}
+  '@biomejs/cli-darwin-x64@2.5.2':
+    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.14':
-    resolution: {integrity: sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==}
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
+    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.14':
-    resolution: {integrity: sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==}
+  '@biomejs/cli-linux-arm64@2.5.2':
+    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.14':
-    resolution: {integrity: sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==}
+  '@biomejs/cli-linux-x64-musl@2.5.2':
+    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.14':
-    resolution: {integrity: sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==}
+  '@biomejs/cli-linux-x64@2.5.2':
+    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.14':
-    resolution: {integrity: sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==}
+  '@biomejs/cli-win32-arm64@2.5.2':
+    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.14':
-    resolution: {integrity: sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==}
+  '@biomejs/cli-win32-x64@2.5.2':
+    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -1039,8 +1039,8 @@ packages:
       node-notifier:
         optional: true
 
-  '@jest/create-cache-key-function@30.3.0':
-    resolution: {integrity: sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==}
+  '@jest/create-cache-key-function@30.4.1':
+    resolution: {integrity: sha512-R+xGEtzA95NIsvpXJSROG4t01956dDOt17KpamguY4XOnGvdHNFFXE7Er0C1OAsRjOwiIxpKqOvGlznIGZIQlQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/environment@29.7.0':
@@ -1063,8 +1063,8 @@ packages:
     resolution: {integrity: sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jest/pattern@30.0.1':
-    resolution: {integrity: sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==}
+  '@jest/pattern@30.4.0':
+    resolution: {integrity: sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/reporters@29.7.0':
@@ -1080,8 +1080,8 @@ packages:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jest/schemas@30.0.5':
-    resolution: {integrity: sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==}
+  '@jest/schemas@30.4.1':
+    resolution: {integrity: sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jest/source-map@29.6.3':
@@ -1104,8 +1104,8 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@jest/types@30.3.0':
-    resolution: {integrity: sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==}
+  '@jest/types@30.4.1':
+    resolution: {integrity: sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1308,36 +1308,36 @@ packages:
     peerDependencies:
       '@swc/core': '*'
 
-  '@swc/types@0.1.26':
-    resolution: {integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==}
+  '@swc/types@0.1.27':
+    resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
-  '@turbo/darwin-64@2.9.8':
-    resolution: {integrity: sha512-zU1P95ygDpsQ+2QHh7CVTqvYwi9UBlhKWzoIyUnP3vUoge7H9SQEzrd8dj+XcTrslAp9Db3vIBcXtMVoTEYDnA==}
+  '@turbo/darwin-64@2.10.3':
+    resolution: {integrity: sha512-guuiO2kKc7yUQFU2jhWyM/BrYGD/brqb0+JvJIXTQ/QI1NlWfHZ1id50kkkOWqxmBiDc8DgW2orfY85pQIc7gw==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.8':
-    resolution: {integrity: sha512-nKRFI5ZhCGUi4eXNlrojzWcT/CehMj0raot1WE4lw5qf66ZxZHbRbBqcwNEy+ZLY7RkJJRY+TaU89fuj3BcgGg==}
+  '@turbo/darwin-arm64@2.10.3':
+    resolution: {integrity: sha512-UglEDl/r1/h5Vw6oS6cEE29Jugz2sDLxHCSupNznKatj1fDMRXFqYKFcbvm8RTFhtYPI45NxkrPNo9BqNychBg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.8':
-    resolution: {integrity: sha512-Wf/kQpVDCaWM3P5d6lKvJnqjYn/ofUBGbT4h4vRFrdC4N6B/nsun03S2kQNJJMXpXg39woeS4CI367RMU3/OAg==}
+  '@turbo/linux-64@2.10.3':
+    resolution: {integrity: sha512-KuQxaPWD7OBmwEZqO0sgijwcuXR5eMWbo7BEt2m1D2Q3RylJDj7WMcJ0Btv2VJA0QC+khzAaTAm1yWowJ0CWAw==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.8':
-    resolution: {integrity: sha512-v6S3HuKVoa9CEx16IxKj1i/+crxXx22A9O80zW1350zyUlcX0T/zLOxVf1k+ruK/7ssXnDJVg8uSYOxlYRedlA==}
+  '@turbo/linux-arm64@2.10.3':
+    resolution: {integrity: sha512-DPkIKQ+6p0sho3Cx/e/A3F+AKgXQJA+z//cHsTcyyM1YWRGSYA0UTP8NUpb4iS2tVBSniGwmjRUr73hpq8kcDg==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.8':
-    resolution: {integrity: sha512-JaefWOJNBazDylAn3f+lLB34XMNu8nEBbgPRP/Ewysg81cBubGfcyyyzpQOGVuMwfaqdNAE/kitG7w3AbJn9/g==}
+  '@turbo/windows-64@2.10.3':
+    resolution: {integrity: sha512-8NvFAze9D4PsosZAnK3aGqHz2vLzREz9lNIxLgfE0jRchq2sZQE190cwFm7WX17yg3ftPvwCvWH3rhLbG1UHCQ==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.8':
-    resolution: {integrity: sha512-Or6ljjB4TiiwCdVKDYWew0SokQ9kep5zruL8P3nbum9WdkH5XA41rQID4Ulc215Z+R3DrB+qXSHPsJjU3/n2ng==}
+  '@turbo/windows-arm64@2.10.3':
+    resolution: {integrity: sha512-AqjqV5cHbFa0YRaQ+Dyw6lSm6as4h/Uf8LcZ7VN8i+Odr23ShFD5SUvVAR1d3rZqibFVs9c0VdtXdfQfkdcs3A==}
     cpu: [arm64]
     os: [win32]
 
@@ -1383,8 +1383,8 @@ packages:
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -1891,9 +1891,9 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  find-installed-packages@3.0.3:
-    resolution: {integrity: sha512-B31au+nJZmDvSjNCvTLrOrdq7ZtEgaJSiY5xWF3pxVJS2ApWpnoFVAKwdGKowAA90iPDtpJQqK5YxXXiJ4f2ww==}
-    engines: {node: '>=14'}
+  find-installed-packages@3.1.1:
+    resolution: {integrity: sha512-aFA7JbUCysD/ACS89o2hrEdgMtXV5mm+AJBxySQXGLe7Z+TzFw5YDFlI+6WAOSTKRqbkC5v105ToO0/krRn+4A==}
+    engines: {bun: '>=1.0', node: '>=14'}
 
   find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2265,8 +2265,8 @@ packages:
     resolution: {integrity: sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  jest-regex-util@30.0.1:
-    resolution: {integrity: sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==}
+  jest-regex-util@30.4.0:
+    resolution: {integrity: sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
   jest-resolve-dependencies@29.7.0:
@@ -2856,6 +2856,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -3013,8 +3018,8 @@ packages:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   tmpl@1.0.5:
@@ -3024,8 +3029,8 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  ts-jest@29.4.9:
-    resolution: {integrity: sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==}
+  ts-jest@29.4.11:
+    resolution: {integrity: sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -3054,8 +3059,8 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
-  turbo@2.9.8:
-    resolution: {integrity: sha512-REEB2rVTVDTf4hav1gJ5dIsGylWZrNonvjXFtk1dCi8gND3PhZtnYkyry1bra/Fo+iP6ctTEZbg6vWfdfHq/1A==}
+  turbo@2.10.3:
+    resolution: {integrity: sha512-uZIqzfgtWbyqu1Tqwdd0giRnPGgL0ejbcdF8eZLJhtTTVSrOgArZGzYeXTD6XNcc7ANgdhqex11Y9bHBeyiQLQ==}
     hasBin: true
 
   type-detect@4.0.8:
@@ -3100,8 +3105,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -3414,39 +3419,39 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@biomejs/biome@2.4.14':
+  '@biomejs/biome@2.5.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.14
-      '@biomejs/cli-darwin-x64': 2.4.14
-      '@biomejs/cli-linux-arm64': 2.4.14
-      '@biomejs/cli-linux-arm64-musl': 2.4.14
-      '@biomejs/cli-linux-x64': 2.4.14
-      '@biomejs/cli-linux-x64-musl': 2.4.14
-      '@biomejs/cli-win32-arm64': 2.4.14
-      '@biomejs/cli-win32-x64': 2.4.14
+      '@biomejs/cli-darwin-arm64': 2.5.2
+      '@biomejs/cli-darwin-x64': 2.5.2
+      '@biomejs/cli-linux-arm64': 2.5.2
+      '@biomejs/cli-linux-arm64-musl': 2.5.2
+      '@biomejs/cli-linux-x64': 2.5.2
+      '@biomejs/cli-linux-x64-musl': 2.5.2
+      '@biomejs/cli-win32-arm64': 2.5.2
+      '@biomejs/cli-win32-x64': 2.5.2
 
-  '@biomejs/cli-darwin-arm64@2.4.14':
+  '@biomejs/cli-darwin-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.14':
+  '@biomejs/cli-darwin-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.14':
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.14':
+  '@biomejs/cli-linux-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.14':
+  '@biomejs/cli-linux-x64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.14':
+  '@biomejs/cli-linux-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.14':
+  '@biomejs/cli-win32-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.14':
+  '@biomejs/cli-win32-x64@2.5.2':
     optional: true
 
   '@changesets/apply-release-plan@7.1.1':
@@ -3849,9 +3854,9 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/create-cache-key-function@30.3.0':
+  '@jest/create-cache-key-function@30.4.1':
     dependencies:
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
 
   '@jest/environment@29.7.0':
     dependencies:
@@ -3889,10 +3894,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/pattern@30.0.1':
+  '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 25.6.0
-      jest-regex-util: 30.0.1
+      '@types/node': 26.1.0
+      jest-regex-util: 30.4.0
 
   '@jest/reporters@29.7.0':
     dependencies:
@@ -3927,7 +3932,7 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.10
 
-  '@jest/schemas@30.0.5':
+  '@jest/schemas@30.4.1':
     dependencies:
       '@sinclair/typebox': 0.34.49
 
@@ -3980,13 +3985,13 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@jest/types@30.3.0':
+  '@jest/types@30.4.1':
     dependencies:
-      '@jest/pattern': 30.0.1
-      '@jest/schemas': 30.0.5
+      '@jest/pattern': 30.4.0
+      '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.6.0
+      '@types/node': 26.1.0
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -4044,11 +4049,11 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@repobuddy/biome@2.3.1(@biomejs/biome@2.4.14)':
+  '@repobuddy/biome@2.3.1(@biomejs/biome@2.5.2)':
     dependencies:
-      '@biomejs/biome': 2.4.14
+      '@biomejs/biome': 2.5.2
 
-  '@repobuddy/jest@3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@24.12.2)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@24.12.2)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@24.12.2)))(jest@29.7.0(@types/node@24.12.2))(ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3))':
+  '@repobuddy/jest@3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@24.12.2)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@24.12.2)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@24.12.2)))(jest@29.7.0(@types/node@24.12.2))(ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3))':
     dependencies:
       '@swc/jest': 0.2.39(@swc/core@1.15.33)
       jest: 29.7.0(@types/node@24.12.2)
@@ -4061,22 +4066,22 @@ snapshots:
       jest-watch-suspend: 1.1.2(jest@29.7.0(@types/node@24.12.2))
       jest-watch-toggle-config-2: 2.1.0(jest@29.7.0(@types/node@24.12.2))
       jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@24.12.2))
-      ts-jest: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3)
+      ts-jest: 29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3)
 
-  '@repobuddy/jest@3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@25.6.0)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@25.6.0)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@25.6.0)))(jest@29.7.0(@types/node@25.6.0))(ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.6.0))(typescript@5.9.3))':
+  '@repobuddy/jest@3.4.2(@swc/jest@0.2.39(@swc/core@1.15.33))(jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@26.1.0)))(jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@26.1.0)))(jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@26.1.0)))(jest@29.7.0(@types/node@26.1.0))(ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.0))(typescript@5.9.3))':
     dependencies:
       '@swc/jest': 0.2.39(@swc/core@1.15.33)
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@26.1.0)
       jest-resolve: 29.7.0
       read-pkg-up: 7.0.1
       resolve.imports: 2.0.3
       satisfier: 5.4.2
       type-plus: 7.6.2
     optionalDependencies:
-      jest-watch-suspend: 1.1.2(jest@29.7.0(@types/node@25.6.0))
-      jest-watch-toggle-config-2: 2.1.0(jest@29.7.0(@types/node@25.6.0))
-      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@25.6.0))
-      ts-jest: 29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.6.0))(typescript@5.9.3)
+      jest-watch-suspend: 1.1.2(jest@29.7.0(@types/node@26.1.0))
+      jest-watch-toggle-config-2: 2.1.0(jest@29.7.0(@types/node@26.1.0))
+      jest-watch-typeahead: 2.2.2(jest@29.7.0(@types/node@26.1.0))
+      ts-jest: 29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.0))(typescript@5.9.3)
 
   '@repobuddy/typescript@2.1.0':
     dependencies:
@@ -4145,7 +4150,7 @@ snapshots:
   '@swc/core@1.15.33':
     dependencies:
       '@swc/counter': 0.1.3
-      '@swc/types': 0.1.26
+      '@swc/types': 0.1.27
     optionalDependencies:
       '@swc/core-darwin-arm64': 1.15.33
       '@swc/core-darwin-x64': 1.15.33
@@ -4164,31 +4169,31 @@ snapshots:
 
   '@swc/jest@0.2.39(@swc/core@1.15.33)':
     dependencies:
-      '@jest/create-cache-key-function': 30.3.0
+      '@jest/create-cache-key-function': 30.4.1
       '@swc/core': 1.15.33
       '@swc/counter': 0.1.3
       jsonc-parser: 3.3.1
 
-  '@swc/types@0.1.26':
+  '@swc/types@0.1.27':
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@turbo/darwin-64@2.9.8':
+  '@turbo/darwin-64@2.10.3':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.8':
+  '@turbo/darwin-arm64@2.10.3':
     optional: true
 
-  '@turbo/linux-64@2.9.8':
+  '@turbo/linux-64@2.10.3':
     optional: true
 
-  '@turbo/linux-arm64@2.9.8':
+  '@turbo/linux-arm64@2.10.3':
     optional: true
 
-  '@turbo/windows-64@2.9.8':
+  '@turbo/windows-64@2.10.3':
     optional: true
 
-  '@turbo/windows-arm64@2.9.8':
+  '@turbo/windows-arm64@2.10.3':
     optional: true
 
   '@types/babel__core@7.20.5':
@@ -4243,9 +4248,9 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@types/node@25.6.0':
+  '@types/node@26.1.0':
     dependencies:
-      undici-types: 7.19.2
+      undici-types: 8.3.0
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -4508,14 +4513,14 @@ snapshots:
 
   clibuilder@9.0.0:
     dependencies:
-      find-installed-packages: 3.0.3
+      find-installed-packages: 3.1.1
       find-up: 7.0.0
       js-yaml: 4.1.1
       pad-right: 0.2.2
       search-packages: 2.1.0
       standard-log: 12.1.2
       standard-log-color: 12.1.2(standard-log@12.1.2)
-      tmp: 0.2.5
+      tmp: 0.2.7
       tslib: 2.8.1
       type-plus: 7.6.2
       wordwrap: 1.0.0
@@ -4618,13 +4623,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.6.0):
+  create-jest@29.7.0(@types/node@26.1.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.6.0)
+      jest-config: 29.7.0(@types/node@26.1.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4858,7 +4863,7 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  find-installed-packages@3.0.3:
+  find-installed-packages@3.1.1:
     dependencies:
       temp: 0.9.4
       unpartial: 1.0.5
@@ -5195,16 +5200,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.6.0):
+  jest-cli@29.7.0(@types/node@26.1.0):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.6.0)
+      create-jest: 29.7.0(@types/node@26.1.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.6.0)
+      jest-config: 29.7.0(@types/node@26.1.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -5244,7 +5249,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@25.6.0):
+  jest-config@29.7.0(@types/node@26.1.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -5269,7 +5274,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.6.0
+      '@types/node': 26.1.0
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5356,7 +5361,7 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-regex-util@30.0.1: {}
+  jest-regex-util@30.4.0: {}
 
   jest-resolve-dependencies@29.7.0:
     dependencies:
@@ -5479,10 +5484,10 @@ snapshots:
       jest: 29.7.0(@types/node@24.12.2)
       unpartial: 0.6.4
 
-  jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@25.6.0)):
+  jest-watch-suspend@1.1.2(jest@29.7.0(@types/node@26.1.0)):
     dependencies:
       chalk: 2.4.2
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@26.1.0)
       unpartial: 0.6.4
 
   jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@24.12.2)):
@@ -5490,10 +5495,10 @@ snapshots:
       chalk: 4.1.2
       jest: 29.7.0(@types/node@24.12.2)
 
-  jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@25.6.0)):
+  jest-watch-toggle-config-2@2.1.0(jest@29.7.0(@types/node@26.1.0)):
     dependencies:
       chalk: 4.1.2
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@26.1.0)
 
   jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@24.12.2)):
     dependencies:
@@ -5506,11 +5511,11 @@ snapshots:
       string-length: 5.0.1
       strip-ansi: 7.2.0
 
-  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@25.6.0)):
+  jest-watch-typeahead@2.2.2(jest@29.7.0(@types/node@26.1.0)):
     dependencies:
       ansi-escapes: 6.2.1
       chalk: 5.6.2
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@26.1.0)
       jest-regex-util: 29.6.3
       jest-watcher: 29.7.0
       slash: 5.1.0
@@ -5547,12 +5552,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.6.0):
+  jest@29.7.0(@types/node@26.1.0):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.6.0)
+      jest-cli: 29.7.0(@types/node@26.1.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6004,6 +6009,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  semver@7.8.5: {}
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -6163,7 +6170,7 @@ snapshots:
 
   tinyexec@1.1.2: {}
 
-  tmp@0.2.5: {}
+  tmp@0.2.7: {}
 
   tmpl@1.0.5: {}
 
@@ -6171,28 +6178,28 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@25.6.0))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(esbuild@0.20.2)(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.0))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@25.6.0)
+      jest: 29.7.0(@types/node@26.1.0)
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.7.4
+      semver: 7.8.5
       type-fest: 4.41.0
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.0
       '@jest/transform': 29.7.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       babel-jest: 29.7.0(@babel/core@7.29.0)
       esbuild: 0.20.2
       jest-util: 29.7.0
 
-  ts-jest@29.4.9(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.3.0)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@30.4.1)(babel-jest@29.7.0(@babel/core@7.29.0))(jest-util@29.7.0)(jest@29.7.0(@types/node@24.12.2))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
@@ -6201,27 +6208,27 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.7.4
+      semver: 7.8.5
       type-fest: 4.41.0
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
       '@babel/core': 7.29.0
       '@jest/transform': 29.7.0
-      '@jest/types': 30.3.0
+      '@jest/types': 30.4.1
       babel-jest: 29.7.0(@babel/core@7.29.0)
       jest-util: 29.7.0
 
   tslib@2.8.1: {}
 
-  turbo@2.9.8:
+  turbo@2.10.3:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.8
-      '@turbo/darwin-arm64': 2.9.8
-      '@turbo/linux-64': 2.9.8
-      '@turbo/linux-arm64': 2.9.8
-      '@turbo/windows-64': 2.9.8
-      '@turbo/windows-arm64': 2.9.8
+      '@turbo/darwin-64': 2.10.3
+      '@turbo/darwin-arm64': 2.10.3
+      '@turbo/linux-64': 2.10.3
+      '@turbo/linux-arm64': 2.10.3
+      '@turbo/windows-64': 2.10.3
+      '@turbo/windows-arm64': 2.10.3
 
   type-detect@4.0.8: {}
 
@@ -6255,7 +6262,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@7.19.2: {}
+  undici-types@8.3.0: {}
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
- bump safe (non-major) deps repo-wide: find-installed-packages, tmp, ts-jest, npm-run-all2, rimraf, biome, turbo, commitlint, jest-watch-typeahead
- replace .then() chains with async/await in builder.ts and plugins.ts
- bump clibuilder engines.node from >= 8 to >= 18 to match actual ESM support