### PR TITLE
perf(clibuilder): load plugin tooling lazily

### DIFF
--- a/.changeset/lazy-plugin-tooling.md
+++ b/.changeset/lazy-plugin-tooling.md
@@ -1,0 +1,7 @@
+---
+"clibuilder": patch
+---
+
+Load `find-installed-packages` and `search-packages` lazily.
+
+They are only needed by `plugins list` and `plugins search`, but `commands.ts` sits on the startup path of every CLI invocation. They are now pulled in with a dynamic `import()` at call time, cutting roughly 20ms off startup.

--- a/packages/clibuilder/ts/commands.ts
+++ b/packages/clibuilder/ts/commands.ts
@@ -1,7 +1,15 @@
-import { findByKeywords } from 'find-installed-packages'
-import { searchByKeywords } from 'search-packages'
 import { command } from './command.js'
 import { z } from './zod.js'
+
+// `find-installed-packages` and `search-packages` are only needed by `plugins list` and
+// `plugins search`, yet `commands.ts` sits on the startup path of every CLI invocation.
+// Loading them lazily keeps ~16ms of module init off that path.
+// They stay in `context` so tests can still substitute a fake.
+const findByKeywords: typeof import('find-installed-packages').findByKeywords = async (...args) =>
+	(await import('find-installed-packages')).findByKeywords(...args)
+
+const searchByKeywords: typeof import('search-packages').searchByKeywords = async (...args: any[]): Promise<any> =>
+	(await import('search-packages')).searchByKeywords(...(args as [string[]]))
 
 export function getBaseCommand(description: string) {
 	return command({


### PR DESCRIPTION
## What

`find-installed-packages` and `search-packages` are now loaded with a dynamic `import()` at call time instead of statically at the top of `ts/commands.ts`.

## Why

`commands.ts` sits on the startup path of every CLI invocation (`index.ts → cli.ts → builder.ts → commands.ts`), but those two packages are only reachable from `plugins list` and `plugins search`. Every invocation was paying to load a `node_modules` scanner and an npm-registry search wrapper it almost never uses. Measured in isolation on this machine: `find-installed-packages` ~16ms, `search-packages` ~4ms.

## Keeping the test seam

Both functions are injected through each command's `context` field, which `ts/commands.spec.ts` relies on to substitute fakes. I kept `context: { findByKeywords }` / `context: { searchByKeywords }` and made the module-level binding a thin wrapper that does the dynamic import in its body, rather than changing the context value into a loader/thunk.

Reasoning: the wrapper preserves the exact call signature, so the command bodies, the context types, and every existing substitution in the specs stay unchanged — a fake is still just a function with the same shape. A thunk would have changed the context's contract and forced every test fake (and any downstream consumer overriding these) to be rewritten, for no additional laziness.

## Both builds

- **esm** (tsc, `module: NodeNext`): dynamic import preserved as-is.
- **cjs** (esbuild `--bundle`): esbuild keeps the two packages in the bundle but wraps them in its `__esm` / `__commonJS` lazy-init closures, so their bodies only execute on first call. Verified in the built `cjs/index.js`: the only references are inside the lazy arrow at the dynamic-import site, and `require.cache` after `require('./cjs/index.js')` contains neither package.

## Numbers

Warm, Node 24, median of 10 runs against the built output:

| entry | before | after |
|---|---|---|
| `esm/index.js` | 84.9 ms | 63.1 ms |
| `cjs/index.js` | 21.2 ms | 19.4 ms |

(The cjs win is smaller because the bundle never paid module-resolution cost; only deferred execution is saved.)

## Verification

- Full test suite green (195 passed, 3 skipped, 1 todo). The existing `plugins list` "no plugin" spec exercises the real lazy path, not a fake.
- `plugins list` and `plugins search` confirmed working end-to-end against both the `esm/` and `cjs/` builds with a real CLI (`search` hit the live npm registry and returned results).
- `biome lint` / `biome check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)