### PR TITLE
perf: resolve the CLI config with a single directory walk

### DIFF
--- a/.changeset/khaki-pugs-brake.md
+++ b/.changeset/khaki-pugs-brake.md
@@ -1,0 +1,21 @@
+---
+"clibuilder": minor
+---
+
+Resolve the config file with a single upward directory walk instead of one walk per candidate name.
+
+`getConfigFilenames()` produces ~28 candidate names, and each one used to be searched with its own
+`findUpSync()` call — 28 walks from `cwd` to the filesystem root to answer one question. Each ancestor
+directory is now read once and matched against every candidate. From a directory 13 levels below the
+config, the lookup drops from 165 `stat` calls to 13 `readdir` calls (~0.51 ms to ~0.15 ms); when no
+config exists, from 580 `stat` calls to 40.
+
+**Behavior change — nearest config now wins.** Because candidates used to be searched one full walk at
+a time, a lower-priority name in a *nearer* directory lost to a higher-priority name in a *farther*
+one: a `foorc.json` in a grandparent beat a `foo.yaml` in the current directory. Resolution is now
+directory-first — the nearest ancestor containing any candidate wins, and the candidate order only
+breaks ties within that directory. This matches how other config loaders behave. Projects with config
+files at more than one level of the tree may now load a different file.
+
+`find-up` is no longer a dependency; the walk used for `package.json` lookup moved to an internal
+helper as well.

--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -55,7 +55,6 @@
 	},
 	"dependencies": {
 		"find-installed-packages": "^3.1.1",
-		"find-up": "^7.0.0",
 		"js-yaml": "^4.1.1",
 		"pad-right": "^0.2.2",
 		"search-packages": "^2.1.0",

--- a/packages/clibuilder/ts/config.spec.ts
+++ b/packages/clibuilder/ts/config.spec.ts
@@ -1,4 +1,8 @@
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { baseline, execCommand } from '@unional/fixture'
+import { loadConfig } from './config.js'
 
 baseline(
 	{
@@ -16,3 +20,99 @@ baseline(
 		})
 	}
 )
+
+describe('loadConfig() lookup', () => {
+	const ui = { info() {}, debug() {}, warn() {} }
+	const roots: string[] = []
+
+	// each case uses its own config name so nothing above `tmpdir()` can match
+	let counter = 0
+	function nextConfigName() {
+		return `clibuilder-spec-${process.pid}-${counter++}`
+	}
+
+	/**
+	 * Creates `<root>/a/b/c` and writes each entry of `files` relative to `root`.
+	 * Returns the root and the deepest directory to look up from.
+	 */
+	function scaffold(files: Record<string, string>) {
+		const root = mkdtempSync(join(tmpdir(), 'clibuilder-config-'))
+		roots.push(root)
+		const cwd = join(root, 'a', 'b', 'c')
+		mkdirSync(cwd, { recursive: true })
+		// a `package.json` at the root stops the `package.json` fallback from escaping the scaffold
+		writeFileSync(join(root, 'package.json'), '{}')
+		for (const [name, content] of Object.entries(files)) {
+			writeFileSync(join(root, name), content)
+		}
+		return { root, cwd }
+	}
+
+	afterAll(() => {
+		for (const root of roots) rmSync(root, { recursive: true, force: true })
+	})
+
+	it('finds the config in an ancestor directory', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({ [`${name}.json`]: '{"from":"root"}' })
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ from: 'root' })
+	})
+
+	it('finds the dot-prefixed config', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({ [`.${name}rc.json`]: '{"from":"dot-rc"}' })
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ from: 'dot-rc' })
+	})
+
+	it('picks the nearest directory, even when a farther one has a higher priority name', async () => {
+		// `<name>.json` outranks `<name>.yaml` in the candidate list, but `a/b` is nearer than the root.
+		// Previously each candidate was searched to the root in turn, so the root's `.json` won.
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({ [`${name}.json`]: '{"from":"root"}' })
+		writeFileSync(join(root, 'a', 'b', `${name}.yaml`), 'from: nearest')
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ from: 'nearest' })
+	})
+
+	it('picks by candidate order within a directory', async () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({})
+		writeFileSync(join(root, 'a', `${name}.yaml`), 'from: yaml')
+		writeFileSync(join(root, 'a', `${name}.json`), '{"from":"json"}')
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ from: 'json' })
+	})
+
+	it('follows a symlink pointing at a config file', async () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({ 'actual-config.json': '{"from":"symlink"}' })
+		symlinkSync(join(root, 'actual-config.json'), join(root, 'a', `${name}.json`))
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ from: 'symlink' })
+	})
+
+	it('ignores a directory named like a config file', async () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({ [`${name}.json`]: '{"from":"root"}' })
+		mkdirSync(join(root, 'a', `${name}.yaml`))
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ from: 'root' })
+	})
+
+	it('falls back to the package.json entry when no config file is found', async () => {
+		const name = nextConfigName()
+		const { root, cwd } = scaffold({})
+		writeFileSync(join(root, 'package.json'), JSON.stringify({ [name]: { from: 'pjson' } }))
+
+		expect(await loadConfig({ cwd, ui }, name)).toEqual({ from: 'pjson' })
+	})
+
+	it('returns undefined when there is no config anywhere', async () => {
+		const name = nextConfigName()
+		const { cwd } = scaffold({})
+
+		expect(await loadConfig({ cwd, ui }, name)).toBeUndefined()
+	})
+})

--- a/packages/clibuilder/ts/config.ts
+++ b/packages/clibuilder/ts/config.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from 'node:fs'
 import { pathToFileURL } from 'node:url'
-import { findUpSync } from 'find-up'
 import yaml from 'js-yaml'
 import type { UI } from './cli.js'
+import { findAnyFileUp } from './find_up.js'
 import { findPackageJson, getPackageJson } from './platform.js'
 
 export const ctx = {
@@ -21,7 +21,7 @@ export async function loadConfig(
 	configName: string
 ) {
 	const configFileNames = getConfigFilenames(configName)
-	const configFilePath = resolveConfigFilenames(cwd, configFileNames)
+	const configFilePath = findAnyFileUp(cwd, configFileNames)
 	if (configFilePath) {
 		ui.debug(`load config from: ${configFilePath}`)
 		const cfg = await readConfig(configFilePath)
@@ -55,13 +55,6 @@ function getConfigFilenames(configFileName: string) {
 		`${configFileName}rc`
 	]
 	return configFileName.startsWith('.') ? names : names.flatMap((n) => [n, `.${n}`])
-}
-
-function resolveConfigFilenames(cwd: string, filenames: string[]) {
-	for (const filename of filenames) {
-		const filePath = findUpSync(filename, { cwd })
-		if (filePath) return filePath
-	}
 }
 
 // ignoring coverage. Test are done through `@unional/fixture` `execCommand()`

--- a/packages/clibuilder/ts/find_up.ts
+++ b/packages/clibuilder/ts/find_up.ts
@@ -1,0 +1,85 @@
+import { type Dirent, readdirSync, statSync } from 'node:fs'
+import { dirname, join, parse, resolve } from 'node:path'
+
+/**
+ * `darwin` and `win32` default to case-insensitive filesystems,
+ * so a lookup for `foo.json` there should also match `FOO.JSON`.
+ */
+const caseInsensitiveFs = process.platform === 'darwin' || process.platform === 'win32'
+
+/**
+ * Walks up from `cwd` and returns the path of the first ancestor directory containing `filename`.
+ */
+export function findFileUp(cwd: string, filename: string) {
+	for (const dir of ancestors(cwd)) {
+		const filePath = join(dir, filename)
+		if (isFile(filePath)) return filePath
+	}
+}
+
+/**
+ * Walks up from `cwd` and returns the path of the first file matching any of `filenames`.
+ *
+ * Each ancestor directory is read once and matched against every candidate,
+ * so the cost is one `readdir` per directory instead of one walk per candidate.
+ * The nearest directory wins; `filenames` order only breaks ties within a directory.
+ */
+export function findAnyFileUp(cwd: string, filenames: string[]) {
+	for (const dir of ancestors(cwd)) {
+		const entries = readEntries(dir)
+		if (!entries) continue
+		for (const filename of filenames) {
+			const entry = lookup(entries, filename)
+			if (entry && isFileEntry(dir, entry)) return join(dir, entry.name)
+		}
+	}
+}
+
+function* ancestors(cwd: string) {
+	let dir = resolve(cwd)
+	const { root } = parse(dir)
+	while (true) {
+		yield dir
+		if (dir === root) return
+		dir = dirname(dir)
+	}
+}
+
+/**
+ * Indexes the directory by entry name, adding a lower-cased key on case-insensitive
+ * filesystems. An exact name always wins over a case-insensitive one.
+ */
+function readEntries(dir: string) {
+	let dirents: Dirent[]
+	try {
+		dirents = readdirSync(dir, { withFileTypes: true })
+	} catch {
+		return undefined
+	}
+	const entries = new Map<string, Dirent>()
+	for (const dirent of dirents) {
+		entries.set(dirent.name, dirent)
+		if (caseInsensitiveFs) {
+			const lowered = dirent.name.toLowerCase()
+			if (!entries.has(lowered)) entries.set(lowered, dirent)
+		}
+	}
+	return entries
+}
+
+function lookup(entries: Map<string, Dirent>, filename: string) {
+	const entry = entries.get(filename)
+	if (entry || !caseInsensitiveFs) return entry
+	return entries.get(filename.toLowerCase())
+}
+
+function isFileEntry(dir: string, entry: Dirent) {
+	if (entry.isFile()) return true
+	// a symlink pointing at a file counts as a file
+	if (entry.isSymbolicLink()) return isFile(join(dir, entry.name))
+	return false
+}
+
+function isFile(filePath: string) {
+	return statSync(filePath, { throwIfNoEntry: false })?.isFile() ?? false
+}

--- a/packages/clibuilder/ts/platform.ts
+++ b/packages/clibuilder/ts/platform.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from 'node:fs'
-import { findUpSync } from 'find-up'
+import { findFileUp } from './find_up.js'
 
 export const ctx = {
 	pjson: undefined,
@@ -7,7 +7,7 @@ export const ctx = {
 }
 
 export function findPackageJson(appPkgPath: string) {
-	return findUpSync('package.json', { cwd: appPkgPath })
+	return findFileUp(appPkgPath, 'package.json')
 }
 
 export function getPackageJson(pjsonPath: string) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,9 +83,6 @@ importers:
       find-installed-packages:
         specifier: ^3.1.1
         version: 3.1.1
-      find-up:
-        specifier: ^7.0.0
-        version: 7.0.0
       js-yaml:
         specifier: ^4.1.1
         version: 4.1.1
@@ -3896,7 +3893,7 @@ snapshots:
 
   '@jest/pattern@30.4.0':
     dependencies:
-      '@types/node': 26.1.0
+      '@types/node': 24.12.2
       jest-regex-util: 30.4.0
 
   '@jest/reporters@29.7.0':
@@ -3991,7 +3988,7 @@ snapshots:
       '@jest/schemas': 30.4.1
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.1.0
+      '@types/node': 24.12.2
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -4251,6 +4248,7 @@ snapshots:
   '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
+    optional: true
 
   '@types/normalize-package-data@2.4.4': {}
 
@@ -6262,7 +6260,8 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici-types@8.3.0: {}
+  undici-types@8.3.0:
+    optional: true
 
   unicorn-magic@0.1.0: {}
 


### PR DESCRIPTION
## What

`loadConfig()` resolved the CLI's config file by calling `findUpSync()` once per candidate name:

```ts
for (const filename of filenames) {
  const filePath = findUpSync(filename, { cwd })
  if (filePath) return filePath
}
```

`getConfigFilenames()` produces ~28 candidates (`<name>`, the `.cjs`/`.mjs`/`.js`/`.json`/`.yml`/`.yaml`
variants, the `rc` variants, and a dot-prefixed copy of each). That is 28 separate walks from `cwd` to
the filesystem root — 28 × depth `stat` calls to answer one question.

New `ts/find_up.ts` does a single upward walk: each ancestor directory is read once with `readdirSync`
and matched against the whole candidate set, stopping at the first directory that has a hit.
`findPackageJson()` moved to the same helper (a plain `stat` walk, since it looks for one name), so
**`find-up` is no longer a dependency**. `depcheck` is clean.

## Numbers

Measured on Linux, warm, from a directory 13 levels below the config, 200 iterations after a 20-call
warmup. `fs` calls counted with an ESM loader shim over `node:fs` (each maps 1:1 to a syscall).

| | before | after |
|---|---|---|
| config 13 dirs up — time | 0.51 ms/call | **0.15 ms/call** |
| config 13 dirs up — fs calls | 165 `stat` + 1 `readFile` | **13 `readdir` + 1 `readFile`** |
| no config anywhere — fs calls | 580 `stat` | **20 `readdir` + 20 `stat`** |

(The 20 `stat` in the last row are the `package.json` fallback walk, which is unchanged in shape.)

## ⚠️ Behavior change: the nearest config now wins

Because candidates used to be searched *one full walk at a time*, name priority beat directory
proximity: `findUpSync(names[0])` searching the entire ancestor chain won over `findUpSync(names[1])`.
So a `foorc.json` in a **grandparent** beat a `foo.yaml` in the **current directory**.

A per-directory walk inverts this — the nearest ancestor containing any candidate wins, and the
candidate order only breaks ties *within* that directory. Verified against the old code:

```
old (name-priority first): <root>/cfg.json
new (nearest dir first)  : <root>/a/b/cfg.yaml
```

I kept the new ordering rather than preserving the old: nearest-config-wins is what every other config
loader does, and the old ordering is hard to describe as intentional. It is flagged in the changeset
(released as a **minor**, not a patch) and pinned by a test. Projects with config files at more than
one level of the tree may now load a different file.

## Preserved

- **File type** — a match must be a file. `Dirent.isFile()` short-circuits the common case; directories
  named like a config are skipped (test added).
- **Symlinks** — `find-up` follows them by default (`stat`, not `lstat`). A `Dirent` that is a symlink
  is `stat`ed to confirm it points at a file (test added).
- **Case sensitivity** — `readdir` matching is exact, which would have silently regressed macOS and
  Windows, where the filesystem is case-insensitive by default. On those platforms the directory index
  carries a lower-cased key as well; an exact name always wins over a case-insensitive match.
- **Root stop condition** — the walk yields each ancestor and stops after `path.parse(dir).root`, the
  same bound `find-up` uses. Unreadable directories are skipped rather than throwing.

## Tests

8 new cases in `ts/config.spec.ts` driving the public `loadConfig()` (the existing fixture baseline is
untouched): ancestor lookup, dot-prefixed names, **the new nearest-directory ordering**, candidate
order within a directory, symlink following, directory-named-like-a-config, the `package.json`
fallback, and no-config-anywhere.

Full suite green (203 passed), `lint`, `depcheck`, and `coverage` clean. The two uncovered lines in
`find_up.ts` are the case-insensitive-filesystem branches, which cannot execute on the Linux CI runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)