### PR TITLE
feat: add opt-in V8 compile cache helper

### DIFF
--- a/.changeset/wild-pumas-shave.md
+++ b/.changeset/wild-pumas-shave.md
@@ -1,0 +1,17 @@
+---
+"clibuilder": minor
+---
+
+Add `clibuilder/compile-cache`, an opt-in helper to turn on node's V8 compile cache from your cli's bin script.
+
+```js
+import { enableCompileCache } from 'clibuilder/compile-cache'
+
+enableCompileCache()
+
+const { cli } = await import('clibuilder')
+```
+
+Measured on the `test-apps` fixtures (node 24, median of 25 warm runs), startup drops from 86ms to 81ms for the `ESM` build and from 43ms to 37ms for the `CJS` build.
+
+The helper never throws, and does nothing on runtimes without the API (node < 22.1, `bun`, `deno`). `NODE_COMPILE_CACHE` takes precedence when the user sets it.

--- a/packages/clibuilder/README.md
+++ b/packages/clibuilder/README.md
@@ -243,6 +243,75 @@ test('some test', async () => {
 })
 ```
 
+## Startup time
+
+Node can cache the compiled bytecode of every module your CLI loads,
+so the second and later runs skip compiling them again.
+`clibuilder` exposes it as an opt-in helper:
+
+```js
+#!/usr/bin/env node
+import { enableCompileCache } from 'clibuilder/compile-cache'
+
+enableCompileCache()
+
+const { cli } = await import('clibuilder')
+
+cli({ name: 'app', version: '1.0.0' })
+  .default({ run() { /* ...snip... */ } })
+  .parse(process.argv)
+```
+
+or in `CJS`:
+
+```js
+#!/usr/bin/env node
+require('clibuilder/compile-cache').enableCompileCache()
+
+const { cli } = require('clibuilder')
+```
+
+Measured on the `test-apps` fixtures (node 24, median of 25 warm runs):
+
+| build | without | with |
+| ----- | ------- | ---- |
+| `ESM` | 86ms    | 81ms |
+| `CJS` | 43ms    | 37ms |
+
+Two rules make it work, and both are easy to get wrong:
+
+- **Call it first.** The cache applies to modules compiled *after* the call,
+  so it must run before your CLI and its dependencies are loaded.
+  Calling it later — from your command's `run()`, or from inside `cli()` —
+  caches nothing.
+  That is why `clibuilder` does not turn it on for you:
+  by the time `cli()` runs, everything worth caching is already compiled.
+- **In `ESM`, use `await import`.** A static `import` compiles the entire module
+  graph before any of it runs, so a statically imported `cli` is already
+  compiled by the time `enableCompileCache()` executes.
+  `clibuilder/compile-cache` is a separate entry point that pulls in nothing but
+  `node:module`, so importing it statically costs nothing.
+
+The helper never throws.
+On runtimes without the API (node < 22.1, and currently `bun` and `deno`) it
+does nothing and reports why:
+
+```js
+const { enabled, directory, message } = enableCompileCache()
+```
+
+By default node picks the cache location.
+Pass a directory to choose your own:
+
+```js
+enableCompileCache(path.join(os.homedir(), '.cache/my-cli'))
+```
+
+If the user sets the `NODE_COMPILE_CACHE` environment variable,
+their directory wins and the argument is ignored.
+They can also use that variable to switch the cache on for a CLI that does not
+call the helper at all.
+
 ## shebang
 
 To make your CLI easily executable,

--- a/packages/clibuilder/package.json
+++ b/packages/clibuilder/package.json
@@ -25,10 +25,19 @@
 	"sideEffects": false,
 	"type": "module",
 	"exports": {
-		"types": "./esm/index.d.ts",
-		"import": "./esm/index.js",
-		"require": "./cjs/index.js",
-		"default": "./cjs/index.js"
+		".": {
+			"types": "./esm/index.d.ts",
+			"import": "./esm/index.js",
+			"require": "./cjs/index.js",
+			"default": "./cjs/index.js"
+		},
+		"./compile-cache": {
+			"types": "./esm/compile_cache.d.ts",
+			"import": "./esm/compile_cache.js",
+			"require": "./cjs/compile_cache.js",
+			"default": "./cjs/compile_cache.js"
+		},
+		"./package.json": "./package.json"
 	},
 	"main": "./cjs/index.js",
 	"types": "./esm/index.d.ts",
@@ -41,7 +50,7 @@
 	],
 	"scripts": {
 		"build": "run-p build:cjs build:esm",
-		"build:cjs": "esbuild ts/index.ts --bundle --platform=node --outfile=cjs/index.js && ncp package.cjs.json cjs/package.json",
+		"build:cjs": "esbuild ts/index.ts ts/compile_cache.ts --bundle --platform=node --outdir=cjs && ncp package.cjs.json cjs/package.json",
 		"build:esm": "tsc",
 		"build:watch": "tsc --watch",
 		"clean": "rimraf .nyc_output .ts coverage cjs esm lib libm",

--- a/packages/clibuilder/ts/compile_cache.spec.ts
+++ b/packages/clibuilder/ts/compile_cache.spec.ts
@@ -1,0 +1,114 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { ctx, enableCompileCache } from './compile_cache.js'
+
+const original = { ...ctx }
+
+afterEach(() => Object.assign(ctx, original))
+
+function stub(stubs: Partial<typeof ctx>) {
+	Object.assign(ctx, stubs)
+}
+
+const status = { FAILED: 0, ENABLED: 1, ALREADY_ENABLED: 2, DISABLED: 3 }
+
+describe('enableCompileCache()', () => {
+	it('reports not enabled on a runtime without the api', () => {
+		stub({ enableCompileCache: undefined })
+		expect(enableCompileCache()).toEqual({
+			enabled: false,
+			message: 'module.enableCompileCache() is not available on this runtime'
+		})
+	})
+
+	it('does not throw when the api throws', () => {
+		stub({
+			enableCompileCache: () => {
+				throw new Error('nope')
+			}
+		})
+		expect(enableCompileCache()).toEqual({ enabled: false, message: 'nope' })
+	})
+
+	it('does not throw when the api throws a non-error', () => {
+		stub({
+			enableCompileCache: () => {
+				throw 'nope'
+			}
+		})
+		expect(enableCompileCache()).toEqual({ enabled: false, message: 'nope' })
+	})
+
+	it('falls back to the reported directory when the status constants are missing', () => {
+		stub({
+			enableCompileCache: () => ({ status: 1, directory: '/cache' }),
+			compileCacheStatus: undefined,
+			env: {}
+		})
+		expect(enableCompileCache()).toEqual({ enabled: true, directory: '/cache' })
+	})
+
+	it('reports the directory it enabled', () => {
+		stub({
+			enableCompileCache: () => ({ status: status.ENABLED, directory: '/cache' }),
+			compileCacheStatus: status,
+			env: {}
+		})
+		expect(enableCompileCache()).toEqual({ enabled: true, directory: '/cache' })
+	})
+
+	it('treats an already enabled cache as enabled', () => {
+		stub({
+			enableCompileCache: () => ({ status: status.ALREADY_ENABLED, directory: '/cache' }),
+			compileCacheStatus: status,
+			env: {}
+		})
+		expect(enableCompileCache().enabled).toBe(true)
+	})
+
+	it('reports why the cache could not be enabled', () => {
+		stub({
+			enableCompileCache: () => ({ status: status.FAILED, message: 'disk is full' }),
+			compileCacheStatus: status,
+			env: {}
+		})
+		expect(enableCompileCache()).toEqual({ enabled: false, message: 'disk is full' })
+	})
+
+	it('passes the cache dir to node', () => {
+		let received: unknown
+		stub({
+			enableCompileCache: dir => {
+				received = dir
+				return { status: status.ENABLED, directory: String(dir) }
+			},
+			compileCacheStatus: status,
+			env: {}
+		})
+		enableCompileCache('/my-cache')
+		expect(received).toEqual('/my-cache')
+	})
+
+	it('leaves the cache dir to node when NODE_COMPILE_CACHE is set', () => {
+		let received: unknown = '/not-called'
+		stub({
+			enableCompileCache: dir => {
+				received = dir
+				return { status: status.ALREADY_ENABLED, directory: '/from-env' }
+			},
+			compileCacheStatus: status,
+			env: { NODE_COMPILE_CACHE: '/from-env' }
+		})
+		expect(enableCompileCache('/my-cache')).toEqual({ enabled: true, directory: '/from-env' })
+		expect(received).toBeUndefined()
+	})
+
+	it('enables the cache of the running process', () => {
+		const dir = mkdtempSync(path.join(tmpdir(), 'clibuilder-cc-'))
+		const result = enableCompileCache(dir)
+		// node >= 22.1 only. Elsewhere the call is a documented no-op.
+		if (!result.enabled) return
+		expect(result.directory).toBeTruthy()
+	})
+})

--- a/packages/clibuilder/ts/compile_cache.ts
+++ b/packages/clibuilder/ts/compile_cache.ts
@@ -1,0 +1,73 @@
+import module from 'node:module'
+
+export const ctx = {
+	enableCompileCache: module.enableCompileCache?.bind(module),
+	compileCacheStatus: module.constants?.compileCacheStatus,
+	env: process.env
+}
+
+export namespace enableCompileCache {
+	export type Result = {
+		/**
+		 * `true` when the V8 compile cache is active for the rest of this process.
+		 */
+		enabled: boolean
+		/**
+		 * Directory the cache is stored in, when enabled.
+		 */
+		directory?: string
+		/**
+		 * Why the cache could not be enabled.
+		 */
+		message?: string
+	}
+}
+
+/**
+ * Turns on Node's V8 compile cache for the rest of this process.
+ *
+ * Call this as the *first* statement of your cli's bin script, before the modules
+ * you want cached are loaded. It caches nothing that is already compiled, so calling
+ * it after `import 'clibuilder'` (or from inside `cli()`) is a no-op.
+ *
+ * Import it from `clibuilder/compile-cache` — that subpath pulls in nothing but
+ * `node:module`, so reaching it costs no startup time.
+ *
+ * ```js
+ * // esm bin — the dynamic import keeps your cli out of the statically linked graph
+ * import { enableCompileCache } from 'clibuilder/compile-cache'
+ * enableCompileCache()
+ * const { cli } = await import('clibuilder')
+ * ```
+ *
+ * ```js
+ * // cjs bin
+ * require('clibuilder/compile-cache').enableCompileCache()
+ * const { cli } = require('clibuilder')
+ * ```
+ *
+ * Never throws. On runtimes without the API (Node < 22.1, and current bun/deno) it
+ * reports `enabled: false` and leaves the process untouched.
+ *
+ * @param cacheDir Where to store the cache. Defaults to Node's own location.
+ * Ignored when the user has set `NODE_COMPILE_CACHE` — their choice wins.
+ */
+export function enableCompileCache(cacheDir?: string): enableCompileCache.Result {
+	if (!ctx.enableCompileCache) {
+		return { enabled: false, message: 'module.enableCompileCache() is not available on this runtime' }
+	}
+	// the user already picked a directory through the environment. Let node use it.
+	const dir = ctx.env['NODE_COMPILE_CACHE'] ? undefined : cacheDir
+	try {
+		const result = ctx.enableCompileCache(dir)
+		const status = ctx.compileCacheStatus
+		const enabled = status
+			? result.status === status.ENABLED || result.status === status.ALREADY_ENABLED
+			: !!result.directory
+		return enabled
+			? { enabled, directory: result.directory }
+			: { enabled, directory: result.directory, message: result.message }
+	} catch (e: any) {
+		return { enabled: false, message: e?.message ?? String(e) }
+	}
+}

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,8 @@ Key highlights:
 - plugin support: write commands in separate packages and reuse by multiple CLI
 - type inference and validation for config, arguments, and options\
   using [zod](https://github.com/colinhacks/zod) (exported as `z`)
+- opt-in V8 compile cache for faster startup\
+  via `clibuilder/compile-cache`
 
 Learn more in the [`clibuilder` README](./packages/clibuilder/README.md)
 

--- a/test-apps/test-cli-esm/bin.mjs
+++ b/test-apps/test-cli-esm/bin.mjs
@@ -1,4 +1,10 @@
-import { cli } from 'clibuilder'
+import { enableCompileCache } from 'clibuilder/compile-cache'
+
+enableCompileCache()
+
+// `import` compiles the whole graph before this module runs, so the cache would
+// come too late. `await import` keeps clibuilder out of that graph.
+const { cli } = await import('clibuilder')
 
 const app = cli({
 	name: 'test-cli',

--- a/test-apps/test-cli/bin.js
+++ b/test-apps/test-cli/bin.js
@@ -1,3 +1,5 @@
+require('clibuilder/compile-cache').enableCompileCache()
+
 const { cli } = require('clibuilder')
 
 const app = cli({


### PR DESCRIPTION
## What

Adds `clibuilder/compile-cache`, a separate entry point exporting `enableCompileCache()` — an opt-in wrapper over node's `module.enableCompileCache()` for cli authors to call as the first statement of their bin script.

```js
import { enableCompileCache } from 'clibuilder/compile-cache'

enableCompileCache()

const { cli } = await import('clibuilder')
```

## Numbers

End-to-end `node bin.js echo hi` on the `test-apps` fixtures, node 24, median of 25 warm runs (3 warmup runs discarded), measured on this branch:

| build | without | with | delta |
| ----- | ------- | ---- | ----- |
| `ESM` | 85.8ms  | 80.6ms | −6% |
| `CJS` | 42.7ms  | 36.6ms | −14% |

Isolated `import()` of the built entry, same method: `esm/index.js` 70ms → 60ms, `cjs/index.js` 24ms → 17ms.

## Why opt-in, and why a separate entry point

Two measurements drove the design.

**Enabling it inside `cli()` caches nothing.** The compile cache only applies to modules compiled *after* the call. Running a bin that loads clibuilder and *then* enables the cache, against an empty cache directory, leaves **0 entries** written for both builds — and the timings are indistinguishable from no cache at all (`CJS` 46.2ms late vs 45.7ms control vs 35.9ms enabled first). So default-on is not just a library writing to the user's disk unasked; it is that *and* a no-op for the cost it claims to remove. That rules the option out on its own merits, not just on taste.

**In `ESM` the import must be dynamic, and the helper must be dependency-free.** A static `import` compiles the whole module graph before any module body runs, so a side-effect import that enables the cache is already too late for everything imported alongside it. Against an empty cache dir:

| bin shape | cache entries written |
| --------- | --------------------- |
| `import 'enable.mjs'` then static `import 'clibuilder'` | 30 |
| `import 'enable.mjs'` then `await import('clibuilder')` | 170 |
| `NODE_COMPILE_CACHE` env var | 171 |

Hence `clibuilder/compile-cache` pulls in nothing but `node:module` — it is cheap to import statically — and the documented `ESM` pattern uses `await import('clibuilder')`. `NODE_DEBUG_NATIVE=COMPILE_CACHE` on the wired-up fixture confirms every clibuilder `ESM` module is read from cache and accepted.

Document-only was the third option; it leaves every cli author to re-derive feature detection, the `NODE_COMPILE_CACHE` interaction, and the `ESM` ordering trap. The `README` documents all of that, but shipping the four lines that get it right seemed strictly better than describing them.

## Safety

- Feature-detected via `module.enableCompileCache?.()` — captured once into the `ctx` seam the rest of the package uses. On a runtime without the API it returns `{ enabled: false, message }` and touches nothing. Verified end-to-end by preloading a script that deletes the API and running both fixture bins: both exit 0.
- Wrapped in `try`/`catch`; never throws.
- Respects `NODE_COMPILE_CACHE` — when the user has set it, the `cacheDir` argument is not passed through, so their directory wins.
- Not re-exported from the package root, deliberately: `import { enableCompileCache } from 'clibuilder'` would load the library first and silently do nothing.

## Also

- `exports` becomes a subpath map (`.`, `./compile-cache`, `./package.json`); the root entry is unchanged.
- `build:cjs` now bundles both entry points into `cjs/` via `--outdir`. `cjs/index.js` is byte-for-byte the same size as before.
- Both `test-apps` fixtures are wired to the new path so it is exercised.
- 10 unit tests, 100% coverage on the new module; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)