### PR TITLE
test: cover the platform-gated branches in find_up.ts

### DIFF
--- a/packages/clibuilder/ts/commands.ts
+++ b/packages/clibuilder/ts/commands.ts
@@ -8,6 +8,9 @@ import { z } from './zod.js'
 const findByKeywords: typeof import('find-installed-packages').findByKeywords = async (...args) =>
 	(await import('find-installed-packages')).findByKeywords(...args)
 
+// ignoring coverage. Reaching this shim means querying the npm registry for real,
+// so every test substitutes `context.searchByKeywords` instead.
+// istanbul ignore next
 const searchByKeywords: typeof import('search-packages').searchByKeywords = async (...args: any[]): Promise<any> =>
 	(await import('search-packages')).searchByKeywords(...(args as [string[]]))
 

--- a/packages/clibuilder/ts/compile_cache.spec.ts
+++ b/packages/clibuilder/ts/compile_cache.spec.ts
@@ -79,7 +79,7 @@ describe('enableCompileCache()', () => {
 	it('passes the cache dir to node', () => {
 		let received: unknown
 		stub({
-			enableCompileCache: dir => {
+			enableCompileCache: (dir) => {
 				received = dir
 				return { status: status.ENABLED, directory: String(dir) }
 			},
@@ -93,7 +93,7 @@ describe('enableCompileCache()', () => {
 	it('leaves the cache dir to node when NODE_COMPILE_CACHE is set', () => {
 		let received: unknown = '/not-called'
 		stub({
-			enableCompileCache: dir => {
+			enableCompileCache: (dir) => {
 				received = dir
 				return { status: status.ALREADY_ENABLED, directory: '/from-env' }
 			},

--- a/packages/clibuilder/ts/find_up.spec.ts
+++ b/packages/clibuilder/ts/find_up.spec.ts
@@ -1,0 +1,179 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { ctx, findAnyFileUp, findFileUp } from './find_up.js'
+
+const roots: string[] = []
+
+function scaffold() {
+	const root = mkdtempSync(join(tmpdir(), 'clibuilder-find-up-'))
+	roots.push(root)
+	const cwd = join(root, 'a', 'b')
+	mkdirSync(cwd, { recursive: true })
+	return { root, cwd }
+}
+
+/** Two entries differing only in case cannot coexist on a case-insensitive filesystem. */
+function fsIsCaseSensitive() {
+	const dir = mkdtempSync(join(tmpdir(), 'clibuilder-case-probe-'))
+	try {
+		writeFileSync(join(dir, 'Probe'), '')
+		return !existsSync(join(dir, 'probe'))
+	} finally {
+		rmSync(dir, { recursive: true, force: true })
+	}
+}
+
+const itOnCaseSensitiveFs = fsIsCaseSensitive() ? it : it.skip
+const itAsNonRoot = process.getuid?.() === 0 ? it.skip : it
+
+afterEach(() => {
+	ctx.platform = process.platform
+})
+
+afterAll(() => {
+	for (const root of roots) rmSync(root, { recursive: true, force: true })
+})
+
+describe('findFileUp()', () => {
+	it('finds the file in the starting directory', () => {
+		const { cwd } = scaffold()
+		writeFileSync(join(cwd, 'target.txt'), '')
+
+		expect(findFileUp(cwd, 'target.txt')).toEqual(join(cwd, 'target.txt'))
+	})
+
+	it('walks up to an ancestor', () => {
+		const { root, cwd } = scaffold()
+		writeFileSync(join(root, 'target.txt'), '')
+
+		expect(findFileUp(cwd, 'target.txt')).toEqual(join(root, 'target.txt'))
+	})
+
+	it('ignores a directory with a matching name', () => {
+		const { root, cwd } = scaffold()
+		mkdirSync(join(cwd, 'target.txt'))
+		writeFileSync(join(root, 'target.txt'), '')
+
+		expect(findFileUp(cwd, 'target.txt')).toEqual(join(root, 'target.txt'))
+	})
+
+	it('returns undefined at the filesystem root', () => {
+		const { cwd } = scaffold()
+
+		expect(findFileUp(cwd, 'clibuilder-no-such-file-anywhere.txt')).toBeUndefined()
+	})
+
+	it('resolves a relative cwd', () => {
+		expect(findFileUp('.', 'package.json')).toEqual(join(process.cwd(), 'package.json'))
+	})
+})
+
+describe('findAnyFileUp()', () => {
+	it('picks the nearest directory over the higher priority name', () => {
+		const { root, cwd } = scaffold()
+		writeFileSync(join(root, 'first.txt'), '')
+		writeFileSync(join(cwd, 'second.txt'), '')
+
+		expect(findAnyFileUp(cwd, ['first.txt', 'second.txt'])).toEqual(join(cwd, 'second.txt'))
+	})
+
+	it('picks by candidate order within a directory', () => {
+		const { cwd } = scaffold()
+		writeFileSync(join(cwd, 'first.txt'), '')
+		writeFileSync(join(cwd, 'second.txt'), '')
+
+		expect(findAnyFileUp(cwd, ['first.txt', 'second.txt'])).toEqual(join(cwd, 'first.txt'))
+	})
+
+	it('skips a candidate that is a directory and keeps looking', () => {
+		const { root, cwd } = scaffold()
+		mkdirSync(join(cwd, 'first.txt'))
+		writeFileSync(join(root, 'second.txt'), '')
+
+		expect(findAnyFileUp(cwd, ['first.txt', 'second.txt'])).toEqual(join(root, 'second.txt'))
+	})
+
+	it('follows a symlink pointing at a file', () => {
+		const { root, cwd } = scaffold()
+		writeFileSync(join(root, 'actual.txt'), '')
+		symlinkSync(join(root, 'actual.txt'), join(cwd, 'link.txt'))
+
+		expect(findAnyFileUp(cwd, ['link.txt'])).toEqual(join(cwd, 'link.txt'))
+	})
+
+	it('does not follow a symlink pointing at a directory', () => {
+		const { root, cwd } = scaffold()
+		mkdirSync(join(root, 'actual-dir'))
+		symlinkSync(join(root, 'actual-dir'), join(cwd, 'link.txt'))
+		writeFileSync(join(root, 'link.txt'), '')
+
+		expect(findAnyFileUp(cwd, ['link.txt'])).toEqual(join(root, 'link.txt'))
+	})
+
+	it('skips a broken symlink', () => {
+		const { root, cwd } = scaffold()
+		symlinkSync(join(root, 'gone.txt'), join(cwd, 'link.txt'))
+		writeFileSync(join(root, 'link.txt'), '')
+
+		expect(findAnyFileUp(cwd, ['link.txt'])).toEqual(join(root, 'link.txt'))
+	})
+
+	it('returns undefined at the filesystem root', () => {
+		const { cwd } = scaffold()
+
+		expect(findAnyFileUp(cwd, ['clibuilder-no-such-file-anywhere.txt'])).toBeUndefined()
+	})
+
+	// an unreadable ancestor must not abort the walk
+	itAsNonRoot('skips a directory it cannot read', () => {
+		const { root } = scaffold()
+		const walled = join(root, 'walled')
+		const inner = join(walled, 'inner')
+		mkdirSync(inner, { recursive: true })
+		writeFileSync(join(root, 'target.txt'), '')
+		chmodSync(walled, 0o000)
+		try {
+			expect(findAnyFileUp(inner, ['target.txt'])).toEqual(join(root, 'target.txt'))
+		} finally {
+			chmodSync(walled, 0o755)
+		}
+	})
+
+	describe('on a case-insensitive filesystem', () => {
+		it('matches a candidate against a differently cased entry', () => {
+			ctx.platform = 'darwin'
+			const { cwd } = scaffold()
+			writeFileSync(join(cwd, 'TARGET.TXT'), '')
+
+			expect(findAnyFileUp(cwd, ['target.txt'])).toEqual(join(cwd, 'TARGET.TXT'))
+		})
+
+		it('matches a mixed case candidate against a lower case entry', () => {
+			ctx.platform = 'darwin'
+			const { cwd } = scaffold()
+			writeFileSync(join(cwd, 'target.txt'), '')
+
+			expect(findAnyFileUp(cwd, ['TARGET.txt'])).toEqual(join(cwd, 'target.txt'))
+		})
+
+		itOnCaseSensitiveFs('prefers the exactly cased entry', () => {
+			ctx.platform = 'win32'
+			const { cwd } = scaffold()
+			writeFileSync(join(cwd, 'TARGET.TXT'), '')
+			writeFileSync(join(cwd, 'target.txt'), '')
+
+			expect(findAnyFileUp(cwd, ['target.txt'])).toEqual(join(cwd, 'target.txt'))
+		})
+	})
+
+	describe('on a case-sensitive filesystem', () => {
+		it('does not match a differently cased entry', () => {
+			ctx.platform = 'linux'
+			const { cwd } = scaffold()
+			writeFileSync(join(cwd, 'TARGET.TXT'), '')
+
+			expect(findAnyFileUp(cwd, ['target.txt'])).toBeUndefined()
+		})
+	})
+})

--- a/packages/clibuilder/ts/find_up.ts
+++ b/packages/clibuilder/ts/find_up.ts
@@ -1,11 +1,17 @@
 import { type Dirent, readdirSync, statSync } from 'node:fs'
 import { dirname, join, parse, resolve } from 'node:path'
 
+export const ctx = {
+	platform: process.platform
+}
+
 /**
  * `darwin` and `win32` default to case-insensitive filesystems,
  * so a lookup for `foo.json` there should also match `FOO.JSON`.
  */
-const caseInsensitiveFs = process.platform === 'darwin' || process.platform === 'win32'
+function isCaseInsensitiveFs() {
+	return ctx.platform === 'darwin' || ctx.platform === 'win32'
+}
 
 /**
  * Walks up from `cwd` and returns the path of the first ancestor directory containing `filename`.
@@ -25,11 +31,12 @@ export function findFileUp(cwd: string, filename: string) {
  * The nearest directory wins; `filenames` order only breaks ties within a directory.
  */
 export function findAnyFileUp(cwd: string, filenames: string[]) {
+	const caseInsensitive = isCaseInsensitiveFs()
 	for (const dir of ancestors(cwd)) {
-		const entries = readEntries(dir)
+		const entries = readEntries(dir, caseInsensitive)
 		if (!entries) continue
 		for (const filename of filenames) {
-			const entry = lookup(entries, filename)
+			const entry = lookup(entries, filename, caseInsensitive)
 			if (entry && isFileEntry(dir, entry)) return join(dir, entry.name)
 		}
 	}
@@ -49,7 +56,7 @@ function* ancestors(cwd: string) {
  * Indexes the directory by entry name, adding a lower-cased key on case-insensitive
  * filesystems. An exact name always wins over a case-insensitive one.
  */
-function readEntries(dir: string) {
+function readEntries(dir: string, caseInsensitive: boolean) {
 	let dirents: Dirent[]
 	try {
 		dirents = readdirSync(dir, { withFileTypes: true })
@@ -59,7 +66,7 @@ function readEntries(dir: string) {
 	const entries = new Map<string, Dirent>()
 	for (const dirent of dirents) {
 		entries.set(dirent.name, dirent)
-		if (caseInsensitiveFs) {
+		if (caseInsensitive) {
 			const lowered = dirent.name.toLowerCase()
 			if (!entries.has(lowered)) entries.set(lowered, dirent)
 		}
@@ -67,9 +74,9 @@ function readEntries(dir: string) {
 	return entries
 }
 
-function lookup(entries: Map<string, Dirent>, filename: string) {
+function lookup(entries: Map<string, Dirent>, filename: string, caseInsensitive: boolean) {
 	const entry = entries.get(filename)
-	if (entry || !caseInsensitiveFs) return entry
+	if (entry || !caseInsensitive) return entry
 	return entries.get(filename.toLowerCase())
 }
 


### PR DESCRIPTION
Fixes the `codecov/project` failure on #553.

## Analysis

#553 is the changesets release PR — it touches only changelogs and `package.json`, and
`codecov/patch` passes. The failure is `codecov/project`, which compares against base `28ae843`, so the
drop came from the three PRs merged since then (#554, #555, #556), not from #553 itself:

```
- Coverage   98.57%   98.10%   -0.47%
  Lines         631      686      +55
- Misses          8       11       +3
- Partials        1        2       +1
```

Locating the new misses:

| file | before | after this PR |
|---|---|---|
| `find_up.ts` (#555, mine) | 90.24% stmts, 88.23% branch — lines 63-64, 73 | **100% / 100%** |
| `commands.ts` (#554) | 94.11% stmts — line 12 | **100%** |
| `compile_cache.ts` (#556) | 100% | 100% |

`find_up.ts` was the bulk of it. The case-insensitive-filesystem handling was gated on a module-level
const:

```ts
const caseInsensitiveFs = process.platform === 'darwin' || process.platform === 'win32'
```

Baked in at import time, so on the Linux coverage runner those branches were unreachable by
construction — no test could have covered them. That is my fault in #555; I noted the gap in that PR
but should have made it testable instead.

## Changes

**A `ctx` seam for the platform decision.** `find_up.ts` now exports `ctx = { platform: process.platform }`
and derives case-sensitivity from it, the same convention `config.ts` and `platform.ts` already use for
injecting test doubles. The value is resolved once per `findAnyFileUp()` call and threaded down, rather
than read per directory entry, so the hot loop is unchanged.

**New `ts/find_up.spec.ts`** — 17 cases against the helper directly. Beyond the two filesystem
behaviors, this reaches walk edges the config-level tests never did:

- an ancestor directory that cannot be read (`chmod 000`) must be skipped, not abort the walk
- a symlink to a *directory* must not match, while a symlink to a file must
- a broken symlink must be skipped
- a relative `cwd` resolves against `process.cwd()`

Two guards keep it honest across runners: `prefers the exactly cased entry` needs two entries differing
only in case, so it is skipped when the real filesystem is case-insensitive; the unreadable-directory
case is skipped when running as root, where the permission bits do not apply.

**`commands.ts`** — the lazy `searchByKeywords` shim cannot execute without a live npm registry query
(every test substitutes `context.searchByKeywords`), so it is marked `istanbul ignore next`, as
`listPluginsCommand` already is in the same file.

**`compile_cache.spec.ts`** — formatter only, unrelated to coverage. `pnpm check` is currently red on
main over two `dir =>` / `(dir) =>` arrow parens; called out separately here so it is easy to drop if
you would rather it not ride along.

## Result

`find_up.ts` and `commands.ts` at 100% statements, branches, functions and lines. Project coverage
97.87% → **98.84%**, above the 98.57% base, so `codecov/project` should go green on #553 once this
lands. 230 tests pass; `lint`, `depcheck` and `build` clean.

No changeset: `find_up.ts` is internal and not re-exported from `index.ts`, so nothing here changes the
published surface or behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)